### PR TITLE
Phase 1: driver-to-executor distributed tracing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+Closes #
+
+## Summary
+
+
+## Test plan
+- [ ]

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,25 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# sbt
+target/
+project/target/
+project/project/
+
+# IDE
+.idea/
+.bsp/
+*.iml
+
+# OS
+.DS_Store
+Thumbs.db
+nul
+
+# Claude
+CLAUDE.md
+
+# Docker dev artifacts
+docker/parse-trace.js
+docker/*.jar

--- a/README.md
+++ b/README.md
@@ -1,0 +1,137 @@
+# Flare
+
+OpenTelemetry distributed tracing for Apache Spark — driver-to-executor context propagation.
+
+```
+spark.application  (driver, root)
+├── spark.job.0    (driver)
+│   └── spark.stage.0  (driver)
+├── spark.job.1    (driver)
+│   └── spark.stage.2  (driver)
+├── spark.task.executor  (executor-1, partition 0)  ← Flare
+├── spark.task.executor  (executor-1, partition 1)  ← Flare
+├── spark.task.executor  (executor-2, partition 2)  ← Flare
+└── spark.task.executor  (executor-2, partition 3)  ← Flare
+```
+
+> **Phase 1 note:** Task spans are children of the application span, not of their specific
+> job or stage. The traceparent is injected once at SparkContext init, pointing to the
+> application span. Phase 2 will inject per-job traceparent via ByteBuddy for full
+> hierarchical nesting.
+
+## Overview
+
+Most Spark observability stops at the driver. You get a stage span with an aggregate duration but cannot see which executor ran slow, which partition was skewed, or whether a retry happened on a specific node.
+
+Flare injects a W3C `traceparent` into Spark's `LocalProperty` mechanism at SparkContext init. Local properties serialize into `TaskDescription` and travel to the executor JVM. `ExecutorPlugin.onTaskStart()` extracts the context and creates a real executor-side span with accurate wall-clock timing and the driver trace as parent.
+
+## Features
+
+- **Executor task spans** — real spans on the executor thread, not driver-side approximations
+- **W3C trace continuity** — `traceparent` propagated via Spark's local property channel
+- **Zero code changes** — two JARs, two `--conf` lines on `spark-submit`
+- **OTEL native** — OTLP export to any backend (Grafana Tempo, Jaeger, Honeycomb, Datadog)
+- **Granularity control** — jobs, stages, tasks, or all; plus slow-task and retry-only filters
+- **Sampling** — consistent across the JVM boundary via W3C traceparent flags
+
+## Installation
+
+```bash
+spark-submit \
+  --conf "spark.plugins=io.flare.spark.plugin.FlareSparkPlugin" \
+  --conf "spark.driver.extraClassPath=/opt/flare/flare-spark.jar" \
+  --conf "spark.executor.extraClassPath=/opt/flare/flare-spark.jar" \
+  --conf "spark.driver.extraJavaOptions=\
+    -javaagent:/opt/flare/opentelemetry-javaagent.jar \
+    -Dotel.javaagent.extensions=/opt/flare/flare-spark.jar \
+    -Dotel.service.name=my-app-driver \
+    -Dotel.exporter.otlp.protocol=grpc \
+    -Dotel.exporter.otlp.endpoint=http://your-collector:4317" \
+  --conf "spark.executor.extraJavaOptions=\
+    -javaagent:/opt/flare/opentelemetry-javaagent.jar \
+    -Dotel.javaagent.extensions=/opt/flare/flare-spark.jar \
+    -Dotel.service.name=my-app-executor \
+    -Dotel.exporter.otlp.protocol=grpc \
+    -Dotel.exporter.otlp.endpoint=http://your-collector:4317" \
+  myapp.jar
+```
+
+Both JARs must be accessible on every node. On Kubernetes, bake them into your Spark image. On YARN/EMR, use `--files` and reference via `{{PWD}}`.
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FLARE_TRACE_GRANULARITY` | `stages` | `jobs` / `stages` / `tasks` / `all` |
+| `FLARE_SAMPLING_RATIO` | `0.1` | 0.0-1.0, validated at startup |
+| `FLARE_SLOW_TASK_MS` | `0` (disabled) | Only emit task spans exceeding this ms |
+| `FLARE_RETRY_TASKS_ONLY` | `false` | Only emit spans for retries and speculative tasks |
+| `FLARE_MAX_SPANS_PER_TRACE` | `10000` | Circuit breaker for high-cardinality jobs |
+| `FLARE_ENABLED` | `true` | Kill switch |
+
+Set via `-DFLARE_*` in `extraJavaOptions` or as environment variables.
+
+## Building
+
+Requires Java 17+ and sbt.
+
+```bash
+sbt compile
+sbt assembly  # fat JAR at target/scala-2.13/flare-spark-assembly-*.jar
+```
+
+## Docker
+
+A Spark cluster with Grafana Tempo and Grafana is provided for local development:
+
+```bash
+sbt assembly
+sbt "examples/assembly"
+
+cd docker
+docker compose up -d
+```
+
+This starts a Spark master, two workers, a history server, Alloy (OTLP collector), Tempo, and Grafana. Assembly JARs are bind-mounted from the build tree — just re-run `sbt assembly` and restart the job, no Docker rebuild needed.
+
+Run the skewed partition example:
+
+```bash
+docker compose exec spark-master \
+  /opt/spark/bin/spark-submit \
+  --master spark://spark-master:7077 \
+  --class io.flare.examples.SkewedJob \
+  /opt/flare/flare-examples.jar
+```
+
+Open Grafana at `http://localhost:3000` — navigate to Explore, select Tempo, and search for recent traces.
+
+## Architecture
+
+```
+FlareSparkPlugin
+├── FlareDriverPlugin          # creates application span, injects traceparent,
+│   └── TracingSparkListener   # registers listener for job/stage/SQL spans
+└── FlareExecutorPlugin        # extracts traceparent on executor, creates task spans
+```
+
+Context propagation path:
+
+```
+Driver: SparkContext.setLocalProperty("traceparent", "00-{traceId}-{spanId}-01")
+  → serialized into TaskDescription.properties
+  → sent to executor JVM
+Executor: TaskContext.getLocalProperty("traceparent")
+  → W3C extract → parent context → span with accurate executor-side timing
+```
+
+## Stack
+
+- Scala 2.12 / 2.13, Spark 3.5 / 4.0
+- OpenTelemetry Java Agent 2.16.0 (extension mechanism)
+- OpenTelemetry API 1.50.0
+- munit (tests)
+
+## License
+
+Apache License 2.0

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,76 @@
+import Dependencies._
+
+ThisBuild / organization := "io.github.neutrinic"
+ThisBuild / scalaVersion := scala213
+ThisBuild / crossScalaVersions := Seq(scala212, scala213)
+ThisBuild / versionScheme := Some("semver-spec")
+
+ThisBuild / scalacOptions ++= Seq(
+  "-encoding", "UTF-8",
+  "-deprecation",
+  "-feature",
+  "-unchecked",
+  "-Xlint",
+)
+
+ThisBuild / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+  case Some((2, 12)) => Seq("-Ypartial-unification", "-Ywarn-unused:imports")
+  case Some((2, 13)) => Seq("-Ywarn-unused:imports")
+  case _             => Seq.empty
+})
+
+// Spark version to build against (override with -DsparkVersion=3.5.1)
+val sparkBuildVersion = sys.props.getOrElse("sparkVersion", spark35)
+
+lazy val root = (project in file("."))
+  .aggregate(examples)
+  .settings(
+    name := "flare-spark",
+    libraryDependencies ++= otelBundled ++ otelProvided ++ byteBuddyCompileOnly ++ Seq(
+      "org.apache.spark" %% "spark-core" % sparkBuildVersion % "provided",
+      "org.apache.spark" %% "spark-sql"  % sparkBuildVersion % "provided",
+      "org.slf4j"         % "slf4j-api"  % slf4jVersion      % "provided",
+    ) ++ testDeps(sparkBuildVersion),
+
+    // SPI files — do not let assembly deduplicate these
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", "services", _*) => MergeStrategy.concat
+      case PathList("META-INF", _*)             => MergeStrategy.discard
+      case _                                    => MergeStrategy.first
+    },
+
+    // Bundle OTEL API + context (needed on Spark's app classloader for SparkPlugin).
+    // Everything else (Spark, SLF4J, ByteBuddy, OTEL SDK) is provided.
+    assembly / assemblyOption := (assembly / assemblyOption).value
+      .withIncludeScala(false),
+
+    Test / fork := true,
+    Test / javaOptions ++= Seq(
+      s"-Dspark.version=$sparkBuildVersion",
+    ),
+
+    testFrameworks := Seq(new TestFramework("munit.Framework")),
+  )
+
+lazy val examples = (project in file("examples"))
+  .settings(
+    name := "flare-examples",
+    libraryDependencies ++= Seq(
+      "org.apache.spark" %% "spark-core" % sparkBuildVersion % "provided",
+      "org.apache.spark" %% "spark-sql"  % sparkBuildVersion % "provided",
+    ),
+
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", _*) => MergeStrategy.discard
+      case _                        => MergeStrategy.first
+    },
+
+    assembly / assemblyOption := (assembly / assemblyOption).value
+      .withIncludeScala(false),
+
+    // No cross-compilation for examples — Scala 2.13 only
+    crossScalaVersions := Seq(scala213),
+
+    // No tests in examples
+    Test / test := {},
+  )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,79 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+LABEL maintainer="Flare"
+
+ARG SPARK_VERSION=4.0.0
+ARG SCALA_VERSION=2.13
+ARG JDK_VERSION=21
+ARG OTEL_AGENT_VERSION=2.16.0
+ARG FLARE_VERSION=0.1.0-SNAPSHOT
+
+# ── System dependencies ────────────────────────────────────────────────────────
+# No Python, no Jupyter, no Almond — Flare is JVM-only
+RUN microdnf update -y && \
+    microdnf install -y \
+      java-${JDK_VERSION}-openjdk-devel \
+      tar gzip curl procps && \
+    microdnf clean all
+
+# ── Environment ────────────────────────────────────────────────────────────────
+ENV JAVA_HOME=/usr/lib/jvm/java-${JDK_VERSION}-openjdk
+ENV SPARK_HOME=/opt/spark
+ENV PATH=$PATH:$SPARK_HOME/bin
+
+# Java 21 module access required by Spark + Arrow
+ENV JAVA_OPTS="\
+  --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+  --add-opens=java.base/java.lang=ALL-UNNAMED \
+  --add-opens=java.base/java.nio=ALL-UNNAMED \
+  --add-opens=java.base/java.util=ALL-UNNAMED \
+  --add-opens=java.base/java.net=ALL-UNNAMED"
+ENV SPARK_DAEMON_JAVA_OPTS="$JAVA_OPTS"
+ENV SPARK_SUBMIT_OPTS="$JAVA_OPTS"
+
+# ── Spark ──────────────────────────────────────────────────────────────────────
+RUN curl -L https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz | \
+    tar -xz -C /opt && \
+    ln -s /opt/spark-${SPARK_VERSION}-bin-hadoop3 ${SPARK_HOME}
+
+RUN mkdir -p \
+    ${SPARK_HOME}/logs \
+    ${SPARK_HOME}/work \
+    ${SPARK_HOME}/spark-events \
+    /opt/flare
+
+# ── OTEL agent (pinned to match Dependencies.scala) ───────────────────────────
+# Both JARs land in /opt/flare so spark-defaults.conf can reference a stable path
+RUN curl -L \
+    https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_AGENT_VERSION}/opentelemetry-javaagent.jar \
+    -o /opt/flare/opentelemetry-javaagent.jar
+
+# ── Flare extension JAR ────────────────────────────────────────────────────────
+# Stage the assembly JAR into docker/ before building:
+#   sbt assembly
+#   cp target/scala-2.13/flare-spark-assembly-0.1.0-SNAPSHOT.jar docker/
+COPY flare-spark-assembly-${FLARE_VERSION}.jar /opt/flare/flare-spark.jar
+
+# ── Spark config ───────────────────────────────────────────────────────────────
+# spark-defaults.conf pre-wires both driver and executor extraJavaOptions.
+# Users get traces with zero additional configuration.
+COPY spark-defaults.conf ${SPARK_HOME}/conf/spark-defaults.conf
+
+# ── Examples JAR (optional, built separately) ──────────────────────────────────
+# Stage into docker/ before building:
+#   cp examples/target/scala-2.13/flare-examples-assembly-*.jar docker/
+COPY flare-examples-assembly*.jar /opt/flare/flare-examples.jar
+
+# ── Entrypoint ─────────────────────────────────────────────────────────────────
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# 8080: Master WebUI
+# 7077: Master port
+# 8081: Worker WebUI
+# 18080: History Server
+# 4040: Application UI (driver)
+EXPOSE 8080 7077 8081 18080 4040
+
+VOLUME ["/opt/spark/logs", "/opt/spark/work", "/opt/spark/spark-events"]
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/alloy-config.alloy
+++ b/docker/alloy-config.alloy
@@ -1,0 +1,24 @@
+// Grafana Alloy configuration — OTLP receiver forwarding traces to Tempo
+
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+
+  output {
+    traces = [otelcol.exporter.otlp.tempo.input]
+  }
+}
+
+otelcol.exporter.otlp "tempo" {
+  client {
+    endpoint = "tempo:4317"
+
+    tls {
+      insecure = true
+    }
+  }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,142 @@
+services:
+
+  # ── Spark cluster ─────────────────────────────────────────────────────────────
+  # JARs and config are bind-mounted from the build tree — just run `sbt assembly`
+  # and restart, no Docker rebuild needed.
+
+  spark-master:
+    image: ghcr.io/neutrinic/flare-spark:latest
+    build: .
+    hostname: spark-master
+    environment:
+      - SPARK_ROLE=master
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317
+      - OTEL_RESOURCE_ATTRIBUTES=cluster.name=flare-dev,environment=development
+      - FLARE_TRACE_GRANULARITY=all
+      - FLARE_SAMPLING_RATIO=1.0
+    ports:
+      - "8080:8080"   # Spark Master UI
+      - "7077:7077"   # Spark Master port
+      - "4040:4040"   # Driver Application UI
+    volumes:
+      - spark-events:/opt/spark/spark-events
+      - spark-logs:/opt/spark/logs
+      - ../target/scala-2.13/flare-spark-assembly-0.1.0-SNAPSHOT.jar:/opt/flare/flare-spark.jar:ro
+      - ../examples/target/scala-2.13/flare-examples-assembly-0.1.0-SNAPSHOT.jar:/opt/flare/flare-examples.jar:ro
+      - ./spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
+      - ./entrypoint.sh:/entrypoint.sh:ro
+    networks: [flare-net]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+
+  spark-worker-1:
+    image: ghcr.io/neutrinic/flare-spark:latest
+    build: .
+    hostname: spark-worker-1
+    environment:
+      - SPARK_ROLE=worker
+      - SPARK_MASTER_URL=spark://spark-master:7077
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317
+      - OTEL_RESOURCE_ATTRIBUTES=cluster.name=flare-dev,environment=development
+      - FLARE_TRACE_GRANULARITY=all
+      - FLARE_SAMPLING_RATIO=1.0
+    ports:
+      - "8081:8081"   # Worker UI
+    volumes:
+      - ../target/scala-2.13/flare-spark-assembly-0.1.0-SNAPSHOT.jar:/opt/flare/flare-spark.jar:ro
+      - ../examples/target/scala-2.13/flare-examples-assembly-0.1.0-SNAPSHOT.jar:/opt/flare/flare-examples.jar:ro
+      - ./spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
+      - ./entrypoint.sh:/entrypoint.sh:ro
+    depends_on:
+      spark-master: { condition: service_healthy }
+    networks: [flare-net]
+
+  spark-worker-2:
+    image: ghcr.io/neutrinic/flare-spark:latest
+    build: .
+    hostname: spark-worker-2
+    environment:
+      - SPARK_ROLE=worker
+      - SPARK_MASTER_URL=spark://spark-master:7077
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317
+      - OTEL_RESOURCE_ATTRIBUTES=cluster.name=flare-dev,environment=development
+      - FLARE_TRACE_GRANULARITY=all
+      - FLARE_SAMPLING_RATIO=1.0
+    ports:
+      - "8082:8081"
+    volumes:
+      - ../target/scala-2.13/flare-spark-assembly-0.1.0-SNAPSHOT.jar:/opt/flare/flare-spark.jar:ro
+      - ../examples/target/scala-2.13/flare-examples-assembly-0.1.0-SNAPSHOT.jar:/opt/flare/flare-examples.jar:ro
+      - ./spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
+      - ./entrypoint.sh:/entrypoint.sh:ro
+    depends_on:
+      spark-master: { condition: service_healthy }
+    networks: [flare-net]
+
+  spark-history:
+    image: ghcr.io/neutrinic/flare-spark:latest
+    build: .
+    hostname: spark-history
+    environment:
+      - SPARK_ROLE=history
+    ports:
+      - "18080:18080"
+    volumes:
+      - spark-events:/opt/spark/spark-events:ro
+      - ./entrypoint.sh:/entrypoint.sh:ro
+    depends_on: [spark-master]
+    networks: [flare-net]
+
+  # ── Observability stack ───────────────────────────────────────────────────────
+
+  alloy:
+    image: grafana/alloy:latest
+    hostname: alloy
+    ports:
+      - "4317:4317"   # OTLP gRPC (Spark → Alloy)
+      - "4318:4318"   # OTLP HTTP
+      - "12345:12345" # Alloy UI
+    volumes:
+      - ./alloy-config.alloy:/etc/alloy/config.alloy:ro
+    command: run /etc/alloy/config.alloy
+    networks: [flare-net]
+
+  tempo:
+    image: grafana/tempo:2.6.1
+    hostname: tempo
+    ports:
+      - "3200:3200"   # Tempo HTTP
+      - "9095:9095"   # Tempo gRPC
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo/config.yaml:ro
+      - tempo-data:/var/tempo
+    command: -config.file=/etc/tempo/config.yaml
+    networks: [flare-net]
+
+  grafana:
+    image: grafana/grafana:latest
+    hostname: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    depends_on: [tempo]
+    networks: [flare-net]
+
+networks:
+  flare-net:
+    driver: bridge
+
+volumes:
+  spark-events:
+  spark-logs:
+  tempo-data:
+  grafana-data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -e
+
+SPARK_MASTER_URL="${SPARK_MASTER_URL:-spark://spark-master:7077}"
+
+# Resolve the container hostname reliably.
+# The `hostname` command is not installed in the slim Spark base image,
+# so fall back to $HOSTNAME (set by bash) or /etc/hostname.
+_HOST="${HOSTNAME:-$(cat /etc/hostname 2>/dev/null || echo 0.0.0.0)}"
+
+# Allow command-line argument to override SPARK_ROLE env var.
+# This enables: docker compose run spark-master run skewed
+if [[ -n "$1" ]]; then
+  SPARK_ROLE="$1"
+fi
+SPARK_ROLE="${SPARK_ROLE:-master}"
+
+# Allow FLARE_* env vars to override spark-defaults.conf values at runtime
+# by appending them as system properties to extraJavaOptions.
+# This avoids having to rebuild the image to change granularity or sampling.
+_flare_jvm_opts=""
+[[ -n "${FLARE_TRACE_GRANULARITY}" ]] && _flare_jvm_opts="$_flare_jvm_opts -DFLARE_TRACE_GRANULARITY=${FLARE_TRACE_GRANULARITY}"
+[[ -n "${FLARE_SAMPLING_RATIO}" ]]    && _flare_jvm_opts="$_flare_jvm_opts -DFLARE_SAMPLING_RATIO=${FLARE_SAMPLING_RATIO}"
+[[ -n "${FLARE_MAX_SPANS_PER_TRACE}" ]] && _flare_jvm_opts="$_flare_jvm_opts -DFLARE_MAX_SPANS_PER_TRACE=${FLARE_MAX_SPANS_PER_TRACE}"
+[[ -n "${FLARE_ENABLED}" ]]           && _flare_jvm_opts="$_flare_jvm_opts -DFLARE_ENABLED=${FLARE_ENABLED}"
+
+export SPARK_DAEMON_JAVA_OPTS="${SPARK_DAEMON_JAVA_OPTS} ${_flare_jvm_opts}"
+
+case "${SPARK_ROLE}" in
+
+  master)
+    echo "[Flare] Starting Spark master on ${_HOST}"
+    exec "${SPARK_HOME}/bin/spark-class" org.apache.spark.deploy.master.Master \
+      --host "${_HOST}" \
+      --port 7077 \
+      --webui-port 8080
+    ;;
+
+  worker)
+    echo "[Flare] Starting Spark worker → ${SPARK_MASTER_URL}"
+    exec "${SPARK_HOME}/bin/spark-class" org.apache.spark.deploy.worker.Worker \
+      --webui-port 8081 \
+      "${SPARK_MASTER_URL}"
+    ;;
+
+  history)
+    echo "[Flare] Starting Spark history server"
+    export SPARK_HISTORY_OPTS="-Dspark.history.fs.logDirectory=/opt/spark/spark-events"
+    exec "${SPARK_HOME}/bin/spark-class" org.apache.spark.deploy.history.HistoryServer
+    ;;
+
+  # Run a named example job and exit.
+  # Usage: docker run flare-spark run <example>
+  # Examples: simple, skewed, pipeline
+  run)
+    EXAMPLE="${2:-simple}"
+    MAIN_CLASS=""
+    case "${EXAMPLE}" in
+      simple)   MAIN_CLASS="io.flare.examples.SimpleJob"   ;;
+      skewed)   MAIN_CLASS="io.flare.examples.SkewedJob"   ;;
+      pipeline) MAIN_CLASS="io.flare.examples.PipelineJob" ;;
+      *)
+        echo "Unknown example: ${EXAMPLE}. Available: simple, skewed, pipeline"
+        exit 1
+        ;;
+    esac
+
+    echo "[Flare] Running example: ${EXAMPLE} (${MAIN_CLASS})"
+    exec "${SPARK_HOME}/bin/spark-submit" \
+      --master "${SPARK_MASTER_URL}" \
+      --class "${MAIN_CLASS}" \
+      /opt/flare/flare-examples.jar
+    ;;
+
+  *)
+    # Pass through arbitrary spark-submit or spark-class invocations
+    echo "[Flare] Executing: $*"
+    exec "$@"
+    ;;
+
+esac

--- a/docker/grafana/provisioning/datasources/tempo.yaml
+++ b/docker/grafana/provisioning/datasources/tempo.yaml
@@ -1,0 +1,20 @@
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    uid: tempo
+    url: http://tempo:3200
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: GET
+      tracesToLogsV2:
+        datasourceUid: ''
+      tracesToMetrics:
+        datasourceUid: ''
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: ''

--- a/docker/spark-defaults.conf
+++ b/docker/spark-defaults.conf
@@ -1,0 +1,46 @@
+# Flare — pre-wired Spark configuration
+# Both driver and executor get the OTEL agent + Flare extension automatically.
+# Users override OTEL_EXPORTER_OTLP_ENDPOINT via environment variable.
+
+spark.eventLog.enabled                true
+spark.eventLog.dir                    /opt/spark/spark-events
+
+# ── Flare SparkPlugin ─────────────────────────────────────────────────────────
+# Registers FlareDriverPlugin (application span, listener, traceparent injection)
+# and FlareExecutorPlugin (executor-side task spans) automatically.
+spark.plugins                         io.flare.spark.plugin.FlareSparkPlugin
+
+# ── Flare + OTEL API on Spark classpath ──────────────────────────────────────
+# The OTEL agent loads flare-spark.jar as an extension, but Spark's PluginContainer
+# loads spark.plugins classes from the application classpath. The agent JAR contains
+# the unshaded OTEL API bridge classes needed by Flare at the application level.
+spark.driver.extraClassPath           /opt/flare/flare-spark.jar
+spark.executor.extraClassPath         /opt/flare/flare-spark.jar
+
+# ── Driver JVM options ────────────────────────────────────────────────────────
+# IMPORTANT: Spark properties files only use the LAST value for a given key.
+# All extraJavaOptions MUST be on a single logical line (use \ for continuation).
+spark.driver.extraJavaOptions \
+  -javaagent:/opt/flare/opentelemetry-javaagent.jar \
+  -Dotel.javaagent.extensions=/opt/flare/flare-spark.jar \
+  -Dotel.service.name=flare-driver \
+  -Dotel.exporter.otlp.protocol=grpc -Dotel.exporter.otlp.endpoint=http://alloy:4317 \
+  -DFLARE_TRACE_GRANULARITY=all \
+  -DFLARE_SAMPLING_RATIO=1.0 \
+  --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+  --add-opens=java.base/java.lang=ALL-UNNAMED \
+  --add-opens=java.base/java.nio=ALL-UNNAMED \
+  --add-opens=java.base/java.util=ALL-UNNAMED
+
+# ── Executor JVM options ──────────────────────────────────────────────────────
+spark.executor.extraJavaOptions \
+  -javaagent:/opt/flare/opentelemetry-javaagent.jar \
+  -Dotel.javaagent.extensions=/opt/flare/flare-spark.jar \
+  -Dotel.service.name=flare-executor \
+  -Dotel.exporter.otlp.protocol=grpc -Dotel.exporter.otlp.endpoint=http://alloy:4317 \
+  -DFLARE_TRACE_GRANULARITY=all \
+  -DFLARE_SAMPLING_RATIO=1.0 \
+  --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+  --add-opens=java.base/java.lang=ALL-UNNAMED \
+  --add-opens=java.base/java.nio=ALL-UNNAMED \
+  --add-opens=java.base/java.util=ALL-UNNAMED

--- a/docker/tempo-config.yaml
+++ b/docker/tempo-config.yaml
@@ -1,0 +1,25 @@
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+  grpc_listen_port: 9095
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+
+ingester:
+  max_block_duration: 5m
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks

--- a/examples/src/main/scala/io/flare/examples/PipelineJob.scala
+++ b/examples/src/main/scala/io/flare/examples/PipelineJob.scala
@@ -1,0 +1,81 @@
+package io.flare.examples
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+
+/**
+ * Multi-job pipeline — demonstrates trace continuity across multiple Spark actions.
+ *
+ * Three chained jobs all share a single trace ID:
+ *   Job 0: Ingest + validate
+ *   Job 1: Transform + enrich
+ *   Job 2: Aggregate + write
+ *
+ * In Grafana the entire pipeline appears as one trace, making it trivial to see
+ * the cumulative latency and which job/stage/executor is the bottleneck.
+ *
+ * Without executor-side spans, Job 2's aggregate would show a flat stage duration.
+ * With Flare, you see individual partition processing times on each executor —
+ * useful when one executor is slower due to GC pressure or node contention.
+ */
+object PipelineJob {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("Flare Example — Multi-Job Pipeline")
+      .getOrCreate()
+
+    println("=== Flare Pipeline Job ===")
+    println("Three-stage pipeline — all jobs share one trace in Grafana")
+
+    // ── Job 0: Ingest ─────────────────────────────────────────────────────────
+    // Uses pure DataFrame API for Spark 3.5 / 4.0 binary compatibility.
+    println("\n--- Job 0: Ingest and validate ---")
+    val raw = spark.range(500000).select(
+      (col("id") % 1000).cast("int").alias("customer_id"),
+      (col("id") % 500 + 1).cast("double").alias("amount"),
+      when(col("id") % 3 === 0, lit("APAC"))
+        .when(col("id") % 3 === 1, lit("EMEA"))
+        .otherwise(lit("AMER")).alias("region"),
+      (col("id") % 10 =!= 0).alias("valid"),
+    )
+
+    val validated = raw.filter(col("valid")).cache()
+    val ingestCount = validated.count()
+    println(s"Ingested $ingestCount valid records (dropped ${500000 - ingestCount})")
+
+    // ── Job 1: Transform ──────────────────────────────────────────────────────
+    println("\n--- Job 1: Transform and enrich ---")
+    val enriched = validated
+      .withColumn("tier",
+        when(col("amount") > 400, "platinum")
+          .when(col("amount") > 200, "gold")
+          .otherwise("standard"))
+      .withColumn("adjusted_amount", col("amount") * 1.1)
+      .cache()
+
+    val tierCounts = enriched.groupBy("tier").count()
+    println("Tier distribution:")
+    tierCounts.show()
+
+    // ── Job 2: Aggregate ──────────────────────────────────────────────────────
+    println("\n--- Job 2: Regional aggregation ---")
+    val regional = enriched
+      .groupBy("region", "tier")
+      .agg(
+        count("*").alias("customers"),
+        sum("adjusted_amount").alias("revenue"),
+        avg("adjusted_amount").alias("avg_order"),
+        max("adjusted_amount").alias("max_order"),
+      )
+      .orderBy(desc("revenue"))
+
+    println("Regional summary:")
+    regional.show()
+
+    println("\n=== Pipeline complete. All 3 jobs visible as one trace in Grafana ===")
+    println("URL: http://localhost:3000")
+    println("Service: flare-driver | Search: 'Flare Example — Multi-Job Pipeline'")
+
+    spark.stop()
+  }
+}

--- a/examples/src/main/scala/io/flare/examples/SimpleJob.scala
+++ b/examples/src/main/scala/io/flare/examples/SimpleJob.scala
@@ -1,0 +1,60 @@
+package io.flare.examples
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+
+/**
+ * Simple batch job — baseline example showing the complete Flare span hierarchy.
+ *
+ * In Grafana you should see:
+ *   spark.application
+ *   └── spark.job.0
+ *       ├── spark.stage.0  (generate + cache)
+ *       └── spark.stage.1  (aggregate)
+ *           ├── spark.task.executor (partition 0 — executor-1)
+ *           ├── spark.task.executor (partition 1 — executor-1)
+ *           ├── spark.task.executor (partition 2 — executor-2)
+ *           └── spark.task.executor (partition 3 — executor-2)
+ *
+ * The task spans are created on the executor JVM with the driver trace as parent.
+ * This is what no other open-source OTEL Spark integration provides.
+ */
+object SimpleJob {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("Flare Example — Simple Batch")
+      .getOrCreate()
+
+    println("=== Flare Simple Job ===")
+    println("Generating 100k records across 4 partitions")
+
+    val data = spark.range(100000)
+      .select(
+        col("id"),
+        (rand() * 100).cast("int").alias("value"),
+        when(col("id") % 3 === 0, "A")
+          .when(col("id") % 3 === 1, "B")
+          .otherwise("C").alias("category"),
+      )
+      .repartition(4)
+      .cache()
+
+    val total = data.count()
+    println(s"Total records: $total")
+
+    val aggregated = data
+      .groupBy("category")
+      .agg(
+        count("*").alias("count"),
+        avg("value").alias("avg_value"),
+        max("value").alias("max_value"),
+      )
+
+    println("\n--- Aggregation results ---")
+    aggregated.show()
+
+    println("\n=== Job complete. Open Grafana at http://localhost:3000 ===")
+
+    spark.stop()
+  }
+}

--- a/examples/src/main/scala/io/flare/examples/SkewedJob.scala
+++ b/examples/src/main/scala/io/flare/examples/SkewedJob.scala
@@ -1,0 +1,63 @@
+package io.flare.examples
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+
+/**
+ * Skewed partition example — the hero demo for Flare.
+ *
+ * Intentionally creates severe partition skew: one partition gets ~90% of the data,
+ * the rest share 10%. In a driver-side-only tool (Spot, metrics-only APMs), the stage
+ * span shows a single aggregate duration — you cannot see which partition is slow.
+ *
+ * With Flare, each executor task span shows its actual wall-clock duration on the
+ * executor thread. In Grafana you immediately see one span taking 10x longer than
+ * its siblings, on a specific executor, with the partition ID as an attribute.
+ *
+ * This is the trace you should screenshot for the README.
+ */
+object SkewedJob {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("Flare Example — Skewed Partitions")
+      .getOrCreate()
+
+    println("=== Flare Skewed Job ===")
+    println("Generating skewed dataset — partition 0 gets 90% of records")
+    println("Watch Grafana: executor task spans will show dramatic duration skew")
+
+    // Create 1M records where partition key 0 appears 900k times
+    // and keys 1-9 share the remaining 100k records equally.
+    // Uses pure DataFrame API for Spark 3.5 / 4.0 binary compatibility.
+    val skewedData = spark.range(1000000).select(
+      when(col("id") < 900000, lit(0))
+        .otherwise(((col("id") - 900000) % 9 + 1).cast("int"))
+        .alias("partition_key"),
+      (col("id") * 31 + 17).cast("double").alias("value"),
+    )
+
+    println("\n--- Stage 1: Skewed shuffle (watch task span durations) ---")
+    val aggregated = skewedData
+      .groupBy("partition_key")
+      .agg(
+        count("*").alias("record_count"),
+        avg("value").alias("avg_value"),
+        sum("value").alias("total_value"),
+      )
+      .cache()
+
+    aggregated.show()
+
+    println("\n--- Stage 2: Post-shuffle processing (balanced, fast) ---")
+    aggregated
+      .filter(col("record_count") > 100)
+      .orderBy(desc("record_count"))
+      .show()
+
+    println("\n=== Job complete. Open Grafana at http://localhost:3000 ===")
+    println("Find the trace for 'Flare Example — Skewed Partitions'")
+    println("Observe: one task span will be ~10x longer than its siblings")
+
+    spark.stop()
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,47 @@
+import sbt._
+
+object Dependencies {
+
+  val scala212 = "2.12.18"
+  val scala213 = "2.13.16"
+
+  val spark33 = "3.3.4"
+  val spark34 = "3.4.3"
+  val spark35 = "3.5.1"
+  val spark40 = "4.0.0"
+
+  val otelVersion      = "1.50.0"
+  val otelAgentVersion = "2.16.0"
+  val byteBuddyVersion = "1.14.19"
+  val slf4jVersion     = "2.0.16"
+  val munitVersion     = "1.1.1"
+
+  // OTEL API + context — BUNDLED in the assembly JAR.
+  // Phase 1 uses Spark's PluginContainer which loads classes from the application
+  // classloader. The OTEL agent's extension classloader is separate, so the API
+  // must be on the app classpath for FlareSparkPlugin to resolve OTEL types.
+  // Phase 2 (InstrumentationModule via ByteBuddy) will move these back to provided.
+  val otelBundled = Seq(
+    "io.opentelemetry" % "opentelemetry-api"     % otelVersion,
+    "io.opentelemetry" % "opentelemetry-context"  % otelVersion,
+  )
+
+  // OTEL SDK + autoconfigure — provided by the agent, not bundled
+  val otelProvided = Seq(
+    "io.opentelemetry" % "opentelemetry-sdk"                             % otelVersion % "provided",
+    "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure-spi" % otelVersion % "provided",
+  )
+
+  // Provided by the OTEL agent at runtime
+  val byteBuddyCompileOnly = Seq(
+    "net.bytebuddy" % "byte-buddy"       % byteBuddyVersion % "provided",
+    "net.bytebuddy" % "byte-buddy-agent" % byteBuddyVersion % "provided",
+  )
+
+  def testDeps(sparkVersion: String) = Seq(
+    "org.scalameta"    %% "munit"                     % munitVersion % Test,
+    "io.opentelemetry"  % "opentelemetry-sdk-testing" % otelVersion  % Test,
+    "org.apache.spark" %% "spark-core"                % sparkVersion % Test,
+    "org.apache.spark" %% "spark-sql"                 % sparkVersion % Test,
+  )
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.eed3si9n"  % "sbt-assembly"  % "2.3.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.2")

--- a/src/main/scala/io/flare/spark/BuildInfo.scala
+++ b/src/main/scala/io/flare/spark/BuildInfo.scala
@@ -1,0 +1,7 @@
+package io.flare.spark
+
+// Placeholder until sbt-buildinfo is wired up (issue #9).
+// Provides a single source of truth for version across all Flare components.
+private[spark] object BuildInfo {
+  val version = "0.1.0-SNAPSHOT"
+}

--- a/src/main/scala/io/flare/spark/SpanCompat.scala
+++ b/src/main/scala/io/flare/spark/SpanCompat.scala
@@ -1,0 +1,28 @@
+package io.flare.spark
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.{Span, SpanBuilder}
+
+/**
+ * Scala-Java interop helpers for OTEL's setAttribute.
+ *
+ * Java's AttributeKey is invariant in T, so Scala's Long (scala.Long) does not
+ * match java.lang.Long in the generic setAttribute[T](AttributeKey[T], T) context.
+ * These helpers box explicitly, avoiding the invariance mismatch.
+ */
+private[spark] object SpanCompat {
+
+  implicit class RichSpan(private val span: Span) extends AnyVal {
+    def setLong(key: AttributeKey[java.lang.Long], value: Long): Span =
+      span.setAttribute(key, java.lang.Long.valueOf(value))
+    def setBool(key: AttributeKey[java.lang.Boolean], value: Boolean): Span =
+      span.setAttribute(key, java.lang.Boolean.valueOf(value))
+  }
+
+  implicit class RichSpanBuilder(private val sb: SpanBuilder) extends AnyVal {
+    def setLong(key: AttributeKey[java.lang.Long], value: Long): SpanBuilder =
+      sb.setAttribute(key, java.lang.Long.valueOf(value))
+    def setBool(key: AttributeKey[java.lang.Boolean], value: Boolean): SpanBuilder =
+      sb.setAttribute(key, java.lang.Boolean.valueOf(value))
+  }
+}

--- a/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
+++ b/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
@@ -1,0 +1,58 @@
+package io.flare.spark.attributes
+
+import io.opentelemetry.api.common.AttributeKey
+
+object SparkAttributes {
+
+  object Application {
+    val Id      = AttributeKey.stringKey("spark.application.id")
+    val Name    = AttributeKey.stringKey("spark.application.name")
+    val Master  = AttributeKey.stringKey("spark.master.url")
+    val Version = AttributeKey.stringKey("spark.version")
+  }
+
+  object Job {
+    val Id          = AttributeKey.longKey("spark.job.id")
+    val Result      = AttributeKey.stringKey("spark.job.result")
+    val Description = AttributeKey.stringKey("spark.job.description")
+    val StageCount  = AttributeKey.longKey("spark.job.stage.count")
+  }
+
+  object Stage {
+    val Id              = AttributeKey.longKey("spark.stage.id")
+    val AttemptId       = AttributeKey.longKey("spark.stage.attempt.id")
+    val Name            = AttributeKey.stringKey("spark.stage.name")
+    val TaskCount       = AttributeKey.longKey("spark.stage.task.count")
+    val ExecutorRunTime = AttributeKey.longKey("spark.stage.executor.run_time_ms")
+    val ExecutorCpuTime = AttributeKey.longKey("spark.stage.executor.cpu_time_ms")
+    val InputBytes      = AttributeKey.longKey("spark.stage.input.bytes")
+    val InputRecords    = AttributeKey.longKey("spark.stage.input.records")
+    val OutputBytes     = AttributeKey.longKey("spark.stage.output.bytes")
+    val OutputRecords   = AttributeKey.longKey("spark.stage.output.records")
+    val ShuffleReadBytes  = AttributeKey.longKey("spark.stage.shuffle.read_bytes")
+    val ShuffleWriteBytes = AttributeKey.longKey("spark.stage.shuffle.write_bytes")
+    val MemorySpilled   = AttributeKey.longKey("spark.stage.memory.spilled_bytes")
+    val FailureReason   = AttributeKey.stringKey("spark.stage.failure_reason")
+  }
+
+  object Task {
+    val ExecutorId  = AttributeKey.stringKey("spark.task.executor.id")
+    val Host        = AttributeKey.stringKey("spark.task.host")
+    val PartitionId = AttributeKey.longKey("spark.task.partition.id")
+    val AttemptId   = AttributeKey.longKey("spark.task.attempt.id")
+    val Speculative = AttributeKey.booleanKey("spark.task.speculative")
+    val Result      = AttributeKey.stringKey("spark.task.result")
+    val Locality    = AttributeKey.stringKey("spark.task.locality")
+  }
+
+  // OTEL semantic conventions
+  object Error {
+    val Type    = AttributeKey.stringKey("error.type")
+    val Message = AttributeKey.stringKey("error.message")
+  }
+
+  object Flare {
+    val Version          = AttributeKey.stringKey("flare.version")
+    val TraceGranularity = AttributeKey.stringKey("flare.trace.granularity")
+  }
+}

--- a/src/main/scala/io/flare/spark/config/FlareAutoConfig.scala
+++ b/src/main/scala/io/flare/spark/config/FlareAutoConfig.scala
@@ -1,0 +1,50 @@
+package io.flare.spark.config
+
+import io.flare.spark.BuildInfo
+import io.opentelemetry.sdk.autoconfigure.spi.{AutoConfigurationCustomizer, AutoConfigurationCustomizerProvider}
+
+import java.util.logging.Logger
+
+/**
+ * Registered via ServiceLoader SPI. Called by the OTEL agent during autoconfiguration.
+ * Detects driver vs executor role and sets appropriate resource attributes.
+ *
+ * IMPORTANT: This class is loaded by the OTEL agent's extension classloader BEFORE
+ * Spark starts. SLF4J is shaded inside the agent and NOT visible to extensions.
+ * Use java.util.logging (always on bootstrap classpath) instead.
+ */
+class FlareAutoConfig extends AutoConfigurationCustomizerProvider {
+
+  private val logger = Logger.getLogger(classOf[FlareAutoConfig].getName)
+
+  override def customize(customizer: AutoConfigurationCustomizer): Unit = {
+    val config = FlareConfig.load()
+
+    if (!config.enabled) {
+      logger.info("[Flare] Disabled via FLARE_ENABLED=false")
+      return
+    }
+
+    val role = detectRole()
+    logger.info(s"[Flare] Initializing on $role (granularity=${config.granularity}, " +
+      s"sampling=${config.samplingRatio}, maxSpans=${config.maxSpansPerTrace})")
+
+    customizer.addResourceCustomizer { (resource, _) =>
+      import io.opentelemetry.sdk.resources.Resource
+      Resource.builder()
+        .put("flare.role", role)
+        .put("flare.version", BuildInfo.version)
+        .build()
+        .merge(resource)
+    }
+  }
+
+  private def detectRole(): String = {
+    // At agent init time, Spark classes may not be on this classloader.
+    // Only use env vars — SparkEnv is not available to extensions.
+    sys.env.get("SPARK_EXECUTOR_ID") match {
+      case Some(id) if id.nonEmpty => s"executor-$id"
+      case _                       => "driver"
+    }
+  }
+}

--- a/src/main/scala/io/flare/spark/config/FlareConfig.scala
+++ b/src/main/scala/io/flare/spark/config/FlareConfig.scala
@@ -1,0 +1,167 @@
+package io.flare.spark.config
+
+import scala.util.matching.Regex
+
+sealed trait TraceGranularity
+object TraceGranularity {
+  case object Jobs   extends TraceGranularity
+  case object Stages extends TraceGranularity
+  case object Tasks  extends TraceGranularity
+  case object All    extends TraceGranularity
+
+  def fromString(s: String): Either[String, TraceGranularity] = s.toLowerCase.trim match {
+    case "jobs"   => Right(Jobs)
+    case "stages" => Right(Stages)
+    case "tasks"  => Right(Tasks)
+    case "all"    => Right(All)
+    case other    => Left(s"Unknown granularity '$other'. Expected: jobs, stages, tasks, all")
+  }
+}
+
+final case class FlareConfig(
+  enabled:          Boolean,
+  granularity:      TraceGranularity,
+  samplingRatio:    Double,
+  maxSpansPerTrace: Int,
+  slowTaskMs:       Long,    // 0 = disabled, >0 = only emit task spans slower than this
+  retryTasksOnly:   Boolean, // true = only emit spans for retries and speculative tasks
+  // v0.2 — stage-level task filtering
+  // Empty set = no filter (all stages). Non-empty = only these stage IDs get task spans.
+  taskStageIds:     Set[Int],
+  // None = no filter. Some(r) = only stages whose name matches r get task spans.
+  // Compiled once at load time, not per task.
+  taskStagePattern: Option[Regex],
+) {
+  def tracesJobs:        Boolean = enabled
+  def tracesStages:      Boolean = enabled && granularity != TraceGranularity.Jobs
+  def tracesTasks:       Boolean = enabled && (granularity == TraceGranularity.Tasks || granularity == TraceGranularity.All)
+  def tracesTaskDetails: Boolean = enabled && granularity == TraceGranularity.All
+
+  /**
+   * Whether a given task should emit a span.
+   *
+   * All active filters are AND-ed — every condition that is configured must pass.
+   *
+   * At task start, durationMs is unknown (-1) — slow task filter deferred to task end.
+   * At task end, if durationMs < slowTaskMs the caller should drop the span (close scope,
+   * do not call span.end()) rather than recording a span for a fast task.
+   *
+   * stageId / stageName are available from TaskContext on the executor. Pass them when
+   * calling from ExecutorPlugin. Pass -1 / "" when calling from driver-side code (where
+   * stage filtering does not apply — driver spans are never filtered by stage).
+   */
+  def shouldTraceTask(
+    attemptNumber: Int,
+    speculative:   Boolean,
+    stageId:       Int    = -1,
+    stageName:     String = "",
+    durationMs:    Long   = -1L,
+  ): Boolean = {
+    if (!tracesTasks) return false
+    // Stage ID filter — skip if IDs are configured and this stage is not in the set
+    if (taskStageIds.nonEmpty && stageId >= 0 && !taskStageIds.contains(stageId)) return false
+    // Stage name pattern filter — skip if pattern configured and name does not match
+    if (taskStagePattern.isDefined && stageName.nonEmpty &&
+        !taskStagePattern.get.pattern.matcher(stageName).matches()) return false
+    // Retry-only filter
+    if (retryTasksOnly && attemptNumber == 0 && !speculative) return false
+    // Slow task filter — only applied when duration is known (task end)
+    if (slowTaskMs > 0 && durationMs >= 0 && durationMs < slowTaskMs) return false
+    true
+  }
+}
+
+object FlareConfig {
+
+  /**
+   * Read a config value from system properties first, then environment variables.
+   * System properties (-DFLARE_*) are set via spark.driver/executor.extraJavaOptions
+   * and are reliably available on both driver and executor JVMs.
+   * Environment variables are a fallback for direct container env or shell usage.
+   */
+  private def envOrProp(key: String): Option[String] =
+    sys.props.get(key).orElse(sys.env.get(key))
+
+  /** Load and validate config from system properties / env vars. Throws at startup on invalid config. */
+  def load(): FlareConfig = {
+    val enabled = !envOrProp("FLARE_ENABLED")
+      .map(_.toLowerCase).contains("false")
+
+    val granularity = envOrProp("FLARE_TRACE_GRANULARITY")
+      .map(TraceGranularity.fromString)
+      .getOrElse(Right(TraceGranularity.Stages)) match {
+        case Right(g)  => g
+        case Left(err) => throw new IllegalArgumentException(s"Flare config error: $err")
+      }
+
+    val samplingRatio = envOrProp("FLARE_SAMPLING_RATIO")
+      .map { s =>
+        val d = s.toDoubleOption.getOrElse(
+          throw new IllegalArgumentException(s"Flare config error: FLARE_SAMPLING_RATIO '$s' is not a number")
+        )
+        if (d < 0.0 || d > 1.0)
+          throw new IllegalArgumentException(s"Flare config error: FLARE_SAMPLING_RATIO must be 0.0-1.0, got $d")
+        d
+      }
+      .getOrElse(0.1)
+
+    val maxSpansPerTrace = envOrProp("FLARE_MAX_SPANS_PER_TRACE")
+      .map { s =>
+        val n = s.toIntOption.getOrElse(
+          throw new IllegalArgumentException(s"Flare config error: FLARE_MAX_SPANS_PER_TRACE '$s' is not an integer")
+        )
+        if (n <= 0)
+          throw new IllegalArgumentException(s"Flare config error: FLARE_MAX_SPANS_PER_TRACE must be > 0, got $n")
+        n
+      }
+      .getOrElse(10000)
+
+    val slowTaskMs = envOrProp("FLARE_SLOW_TASK_MS")
+      .map { s =>
+        val n = s.toLongOption.getOrElse(
+          throw new IllegalArgumentException(s"Flare config error: FLARE_SLOW_TASK_MS '$s' is not a number")
+        )
+        if (n < 0)
+          throw new IllegalArgumentException(s"Flare config error: FLARE_SLOW_TASK_MS must be >= 0, got $n")
+        n
+      }
+      .getOrElse(0L)
+
+    val retryTasksOnly = envOrProp("FLARE_RETRY_TASKS_ONLY")
+      .map(_.toLowerCase == "true")
+      .getOrElse(false)
+
+    // v0.2 — parsed now so the fields exist, but shouldTraceTask honours them already.
+    // Stage IDs: "7,12,43" → Set(7, 12, 43)
+    val taskStageIds = envOrProp("FLARE_TASK_STAGES")
+      .map { s =>
+        s.split(",").map(_.trim).filter(_.nonEmpty).map { id =>
+          id.toIntOption.getOrElse(
+            throw new IllegalArgumentException(s"Flare config error: FLARE_TASK_STAGES '$id' is not an integer")
+          )
+        }.toSet
+      }
+      .getOrElse(Set.empty[Int])
+
+    // Stage name pattern: compiled once at startup, not per task
+    val taskStagePattern = envOrProp("FLARE_TASK_STAGE_PATTERN")
+      .map { s =>
+        try s.r
+        catch {
+          case e: java.util.regex.PatternSyntaxException =>
+            throw new IllegalArgumentException(s"Flare config error: FLARE_TASK_STAGE_PATTERN '$s' is not valid regex: ${e.getMessage}")
+        }
+      }
+
+    FlareConfig(
+      enabled          = enabled,
+      granularity      = granularity,
+      samplingRatio    = samplingRatio,
+      maxSpansPerTrace = maxSpansPerTrace,
+      slowTaskMs       = slowTaskMs,
+      retryTasksOnly   = retryTasksOnly,
+      taskStageIds     = taskStageIds,
+      taskStagePattern = taskStagePattern,
+    )
+  }
+}

--- a/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
+++ b/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
@@ -1,0 +1,225 @@
+package io.flare.spark.listener
+
+import io.flare.spark.SpanCompat._
+import io.flare.spark.attributes.SparkAttributes._
+import io.flare.spark.config.FlareConfig
+import io.opentelemetry.api.trace.{Span, SpanKind, StatusCode, Tracer}
+import io.opentelemetry.context.Context
+import org.apache.spark.scheduler._
+import org.apache.spark.sql.execution.ui.{
+  SparkListenerSQLExecutionEnd,
+  SparkListenerSQLExecutionStart,
+}
+import org.slf4j.LoggerFactory
+
+import scala.collection.concurrent.TrieMap
+
+/**
+ * Driver-side SparkListener that creates OTEL spans for application, job, and stage lifecycle events.
+ *
+ * IMPORTANT: Task spans are NOT created here. Driver-side task events represent when the driver
+ * heard about task start/end, not actual executor execution time. Real executor-side task spans
+ * are created by FlareExecutorPlugin via ExecutorPlugin.onTaskStart/onTaskEnd.
+ *
+ * Stage→job attribution uses a reverse index built at onJobStart to correctly handle
+ * concurrent jobs (see stageToJob map). Do not use activeJobSpans.headOption.
+ */
+class TracingSparkListener(
+  tracer:  Tracer,
+  config:  FlareConfig,
+  // When true, safeHandle rethrows exceptions instead of swallowing them.
+  // Set to true in tests so assertion failures surface the actual cause.
+  private val throwOnError: Boolean = false,
+) extends SparkListener {
+
+  private val logger = LoggerFactory.getLogger(classOf[TracingSparkListener])
+
+  // All maps use TrieMap for thread safety (LiveListenerBus may change threading model)
+  private val activeJobSpans:   TrieMap[Int, Span]  = TrieMap.empty
+  private val activeStageSpans: TrieMap[Int, Span]  = TrieMap.empty
+  private val activeSQLSpans:   TrieMap[Long, Span] = TrieMap.empty
+
+  // Reverse index: stageId → jobId, built at onJobStart from jobStart.stageIds
+  // Critical for correct parent attribution when multiple jobs run concurrently
+  private val stageToJob: TrieMap[Int, Int] = TrieMap.empty
+
+  // Set by whoever creates this listener (TracingSparkPlugin or ByteBuddy hook)
+  @volatile private var applicationSpan: Option[Span] = None
+
+  def setApplicationSpan(span: Span): Unit = {
+    applicationSpan = Some(span)
+    logger.info(s"[Flare] Application span set: ${span.getSpanContext.getTraceId}")
+  }
+
+  // ── Application ──────────────────────────────────────────────────────────────
+
+  override def onApplicationStart(event: SparkListenerApplicationStart): Unit =
+    logger.info(s"[Flare] Application started: ${event.appName}")
+
+  override def onApplicationEnd(event: SparkListenerApplicationEnd): Unit = {
+    applicationSpan.foreach { span =>
+      span.setStatus(StatusCode.OK)
+      span.end()
+      logger.info("[Flare] Application span ended")
+    }
+  }
+
+  // ── Jobs ─────────────────────────────────────────────────────────────────────
+
+  override def onJobStart(event: SparkListenerJobStart): Unit =
+    if (config.tracesJobs) safeHandle("onJobStart") {
+      val parentContext = applicationSpan
+        .map(Context.current().`with`)
+        .getOrElse(Context.current())
+
+      val span = tracer
+        .spanBuilder(s"spark.job.${event.jobId}")
+        .setSpanKind(SpanKind.INTERNAL)
+        .setParent(parentContext)
+        .startSpan()
+
+      span.setLong(Job.Id, event.jobId.toLong)
+      span.setLong(Job.StageCount, event.stageIds.size.toLong)
+      Option(event.properties.getProperty("spark.job.description"))
+        .foreach(span.setAttribute(Job.Description, _))
+
+      activeJobSpans.put(event.jobId, span)
+
+      // Build reverse index so stages can find their parent job
+      event.stageIds.foreach { stageId =>
+        stageToJob.put(stageId, event.jobId)
+      }
+
+      logger.debug(s"[Flare] Job ${event.jobId} started, stages: ${event.stageIds.mkString(",")}")
+    }
+
+  override def onJobEnd(event: SparkListenerJobEnd): Unit = {
+    // Always clean up stageToJob, even if the job span was missed.
+    // This prevents unbounded growth if onJobStart was lost due to listener registration timing.
+    stageToJob.filterInPlace { case (_, jobId) => jobId != event.jobId }
+
+    activeJobSpans.remove(event.jobId).foreach { span =>
+      safeHandle("onJobEnd") {
+        import org.apache.spark.scheduler.JobSucceeded
+        event.jobResult match {
+          case JobSucceeded =>
+            span.setStatus(StatusCode.OK)
+            span.setAttribute(Job.Result, "SUCCESS")
+          case failed =>
+            span.setStatus(StatusCode.ERROR, failed.toString)
+            span.setAttribute(Job.Result, "FAILED")
+            span.setAttribute(Error.Message, failed.toString)
+        }
+        span.end()
+        logger.debug(s"[Flare] Job ${event.jobId} ended")
+      }
+    }
+  }
+
+  // ── Stages ───────────────────────────────────────────────────────────────────
+
+  override def onStageSubmitted(event: SparkListenerStageSubmitted): Unit =
+    if (config.tracesStages) safeHandle("onStageSubmitted") {
+      val stageId = event.stageInfo.stageId
+
+      // Correct attribution: look up this stage's job, then that job's span
+      val parentSpan: Option[Span] =
+        stageToJob.get(stageId).flatMap(activeJobSpans.get).orElse(applicationSpan)
+
+      parentSpan match {
+        case None =>
+          logger.warn(s"[Flare] No parent span found for stage $stageId, skipping")
+
+        case Some(parent) =>
+          val span = tracer
+            .spanBuilder(s"spark.stage.${stageId}")
+            .setSpanKind(SpanKind.INTERNAL)
+            .setParent(Context.current().`with`(parent))
+            .startSpan()
+
+          span.setLong(Stage.Id, stageId.toLong)
+          span.setLong(Stage.AttemptId, event.stageInfo.attemptNumber().toLong)
+          span.setAttribute(Stage.Name, event.stageInfo.name)
+          span.setLong(Stage.TaskCount, event.stageInfo.numTasks.toLong)
+
+          activeStageSpans.put(stageId, span)
+          logger.debug(s"[Flare] Stage $stageId submitted")
+      }
+    }
+
+  override def onStageCompleted(event: SparkListenerStageCompleted): Unit = {
+    val stageId = event.stageInfo.stageId
+    activeStageSpans.remove(stageId).foreach { span =>
+      safeHandle("onStageCompleted") {
+        // Record task metrics as stage attributes
+        Option(event.stageInfo.taskMetrics).foreach { m =>
+          span.setLong(Stage.ExecutorRunTime, m.executorRunTime)
+          span.setLong(Stage.ExecutorCpuTime, m.executorCpuTime / 1000000L) // ns → ms
+          span.setLong(Stage.InputBytes, m.inputMetrics.bytesRead)
+          span.setLong(Stage.InputRecords, m.inputMetrics.recordsRead)
+          span.setLong(Stage.OutputBytes, m.outputMetrics.bytesWritten)
+          span.setLong(Stage.OutputRecords, m.outputMetrics.recordsWritten)
+          span.setLong(Stage.ShuffleReadBytes, m.shuffleReadMetrics.totalBytesRead)
+          span.setLong(Stage.ShuffleWriteBytes, m.shuffleWriteMetrics.bytesWritten)
+          span.setLong(Stage.MemorySpilled, m.memoryBytesSpilled)
+        }
+
+        event.stageInfo.failureReason match {
+          case Some(reason) =>
+            span.setStatus(StatusCode.ERROR, reason)
+            span.setAttribute(Stage.FailureReason, reason.take(500)) // cap length
+          case None =>
+            span.setStatus(StatusCode.OK)
+        }
+
+        span.end()
+        logger.debug(s"[Flare] Stage $stageId completed")
+      }
+    }
+  }
+
+  // ── SQL ──────────────────────────────────────────────────────────────────────
+
+  override def onOtherEvent(event: SparkListenerEvent): Unit =
+    if (config.tracesStages) {
+      event match {
+        case e: SparkListenerSQLExecutionStart => safeHandle("onSQLStart") {
+          applicationSpan.foreach { parent =>
+            val span = tracer
+              .spanBuilder(s"spark.sql.${e.executionId}")
+              .setSpanKind(SpanKind.INTERNAL)
+              .setParent(Context.current().`with`(parent))
+              .startSpan()
+            activeSQLSpans.put(e.executionId, span)
+          }
+        }
+        case e: SparkListenerSQLExecutionEnd => safeHandle("onSQLEnd") {
+          activeSQLSpans.remove(e.executionId).foreach { span =>
+            span.setStatus(StatusCode.OK)
+            span.end()
+          }
+        }
+        case _ =>
+      }
+    }
+
+  // ── Cleanup ───────────────────────────────────────────────────────────────────
+
+  def shutdown(): Unit = {
+    logger.info("[Flare] Shutting down listener, ending any open spans")
+    Seq[TrieMap[_, Span]](activeStageSpans, activeJobSpans, activeSQLSpans)
+      .foreach { m => m.values.foreach(_.end()); m.clear() }
+    applicationSpan.foreach(_.end())
+    stageToJob.clear()
+  }
+
+  // ── Utilities ─────────────────────────────────────────────────────────────────
+
+  private def safeHandle(eventName: String)(f: => Unit): Unit =
+    try f
+    catch {
+      case ex: Exception =>
+        logger.error(s"[Flare] Error handling $eventName: ${ex.getMessage}", ex)
+        if (throwOnError) throw ex
+    }
+}

--- a/src/main/scala/io/flare/spark/plugin/FlareDriverPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareDriverPlugin.scala
@@ -1,0 +1,109 @@
+package io.flare.spark.plugin
+
+import io.flare.spark.BuildInfo
+import io.flare.spark.attributes.SparkAttributes._
+import io.flare.spark.config.FlareConfig
+import io.flare.spark.listener.TracingSparkListener
+import io.flare.spark.propagation.LocalPropertyPropagator
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.{Span, SpanKind, StatusCode}
+import io.opentelemetry.context.Context
+import org.apache.spark.SparkContext
+import org.apache.spark.api.plugin.{DriverPlugin, PluginContext}
+import org.slf4j.LoggerFactory
+
+import java.{util => ju}
+
+/**
+ * Driver-side plugin that wires everything together on the driver JVM:
+ *
+ * 1. Creates the root application span (SERVER kind)
+ * 2. Injects W3C traceparent into SparkContext local properties so executors
+ *    inherit the trace context via TaskDescription serialization
+ * 3. Registers TracingSparkListener for job/stage/SQL spans on the driver
+ *
+ * This runs inside DriverPlugin.init(), which fires during SparkContext construction
+ * after the LiveListenerBus is started but before any jobs are submitted.
+ *
+ * Phase 1 limitation: traceparent is injected once (pointing to the application span).
+ * All executor task spans will be children of the application span, not of their
+ * specific job/stage span. Phase 2 (ByteBuddy hooking runJob) will inject per-job
+ * traceparent for full hierarchical nesting.
+ */
+class FlareDriverPlugin extends DriverPlugin {
+
+  private val logger = LoggerFactory.getLogger(classOf[FlareDriverPlugin])
+
+  // Written once in init(), read once in shutdown(). Spark guarantees init() completes
+  // before shutdown() is called, so no volatile needed.
+  private var applicationSpan: Option[Span] = None
+  private var listener: Option[TracingSparkListener] = None
+
+  override def init(sc: SparkContext, pluginContext: PluginContext): ju.Map[String, String] = {
+    val config = try FlareConfig.load() catch {
+      case e: IllegalArgumentException =>
+        logger.error(s"[Flare] Configuration error — plugin disabled: ${e.getMessage}")
+        return ju.Collections.emptyMap()
+    }
+
+    if (!config.enabled) {
+      logger.info("[Flare] Disabled via FLARE_ENABLED=false")
+      return ju.Collections.emptyMap()
+    }
+
+    val tracer = GlobalOpenTelemetry.getTracer("io.flare.spark", BuildInfo.version)
+
+    // 1. Create the root application span
+    val appSpan = tracer
+      .spanBuilder("spark.application")
+      .setSpanKind(SpanKind.SERVER)
+      .setAttribute(Application.Name, sc.appName)
+      .setAttribute(Application.Id, sc.applicationId)
+      .setAttribute(Application.Master, sc.master)
+      .setAttribute(Flare.Version, BuildInfo.version)
+      .setAttribute(Flare.TraceGranularity, config.granularity.toString.toLowerCase)
+      .startSpan()
+
+    applicationSpan = Some(appSpan)
+
+    // 2. Inject traceparent into SparkContext local properties.
+    //    SparkContext.localProperties is an InheritableThreadLocal — properties set here
+    //    on the init thread propagate to all child threads and are serialized into
+    //    TaskDescription for each submitted task.
+    val spanContext = Context.current().`with`(appSpan)
+    LocalPropertyPropagator.inject(spanContext, sc)
+
+    // 3. Register TracingSparkListener for driver-side job/stage/SQL spans
+    val tracingListener = new TracingSparkListener(tracer, config)
+    tracingListener.setApplicationSpan(appSpan)
+    sc.addSparkListener(tracingListener)
+    listener = Some(tracingListener)
+
+    logger.info(s"[Flare] Driver plugin initialized — " +
+      s"traceId=${appSpan.getSpanContext.getTraceId}, " +
+      s"granularity=${config.granularity}, " +
+      s"sampling=${config.samplingRatio}")
+
+    ju.Collections.emptyMap()
+  }
+
+  override def shutdown(): Unit = {
+    // Delegate to the listener which ends all open spans (stages, jobs, app).
+    // The listener's shutdown() calls span.end() on the application span.
+    // Span.end() is idempotent, but setStatus after end() is a no-op — so we
+    // must NOT unconditionally set OK here, as that would silently mask an
+    // ERROR status set by the listener's onApplicationEnd or shutdown path.
+    listener.foreach(_.shutdown())
+
+    // Only end the application span directly if the listener was never registered
+    // (e.g., init failed partway through before addSparkListener).
+    if (listener.isEmpty) {
+      applicationSpan.foreach { span =>
+        span.setStatus(StatusCode.OK)
+        span.end()
+      }
+    }
+
+    logger.info("[Flare] Driver plugin shutdown complete")
+  }
+}

--- a/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
@@ -1,0 +1,164 @@
+package io.flare.spark.plugin
+
+import io.flare.spark.BuildInfo
+import io.flare.spark.SpanCompat._
+import io.flare.spark.attributes.SparkAttributes._
+import io.flare.spark.config.{FlareConfig, TraceGranularity}
+import io.flare.spark.propagation.LocalPropertyPropagator
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.{Span, SpanKind, StatusCode}
+import io.opentelemetry.context.Scope
+import org.apache.spark.TaskContext
+import org.apache.spark.TaskFailedReason
+import org.apache.spark.api.plugin.{ExecutorPlugin, PluginContext}
+import org.slf4j.LoggerFactory
+
+import java.{util => ju}
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Executor-side plugin that restores OTEL context from Spark local properties
+ * and creates real executor-side task spans with the correct parent.
+ *
+ * Respects FLARE_TRACE_GRANULARITY — task spans are only created when granularity
+ * is `tasks` or `all`. With `jobs` or `stages`, onTaskStart is a no-op.
+ *
+ * Respects FLARE_SAMPLING_RATIO — samples consistently per trace by checking
+ * the sampling bit already set in the incoming W3C traceparent. If the driver
+ * sampled the trace, the executor follows. No independent sampling decision here.
+ *
+ * Respects FLARE_MAX_SPANS_PER_TRACE — once the per-executor span counter
+ * exceeds the limit, new task spans are suppressed and a warning is logged once.
+ *
+ * Uses ThreadLocal because executor threads are pooled and run tasks serially
+ * per thread, but multiple threads may run tasks concurrently on one executor.
+ */
+class FlareExecutorPlugin extends ExecutorPlugin {
+
+  private val logger = LoggerFactory.getLogger(classOf[FlareExecutorPlugin])
+
+  // Loaded once in init(), then only read — no volatile needed since Spark guarantees
+  // init() completes before any task callbacks fire on this executor.
+  private var config: FlareConfig = _
+
+  // Counts spans created on this executor JVM across all tasks.
+  // Reset is not possible mid-job, so this is a conservative circuit breaker
+  // that prevents unbounded span growth on large jobs.
+  private val spanCount = new AtomicLong(0L)
+
+  // Set to true once the maxSpansPerTrace warning has been logged, to avoid log spam
+  @volatile private var maxSpansWarned = false
+
+  // ThreadLocal holds the active (span, scope) for the current task on this thread.
+  // None means this task was not sampled or granularity suppressed it.
+  private val taskState = new ThreadLocal[Option[(Span, Scope)]]()
+
+  override def init(ctx: PluginContext, extraConf: ju.Map[String, String]): Unit = {
+    config = try FlareConfig.load() catch {
+      case e: IllegalArgumentException =>
+        logger.error(s"[Flare] Configuration error — executor task spans disabled: ${e.getMessage}")
+        // Fall back to a disabled config so onTaskStart is a no-op
+        FlareConfig(enabled = false, granularity = TraceGranularity.Stages,
+          samplingRatio = 0.0, maxSpansPerTrace = 0, slowTaskMs = 0L,
+          retryTasksOnly = false, taskStageIds = Set.empty, taskStagePattern = None)
+    }
+    logger.info(s"[Flare] Executor plugin initialized (granularity=${config.granularity}, " +
+      s"sampling=${config.samplingRatio}, maxSpans=${config.maxSpansPerTrace}, " +
+      s"taskTracing=${config.tracesTasks})")
+  }
+
+  override def onTaskStart(): Unit = {
+    // Guard 1: granularity — tasks must be enabled
+    if (!config.tracesTasks) {
+      taskState.set(None)
+      return
+    }
+
+    val taskContext = TaskContext.get()
+    if (taskContext == null) {
+      logger.warn("[Flare] onTaskStart called with null TaskContext")
+      taskState.set(None)
+      return
+    }
+
+    val parentContext = LocalPropertyPropagator.extract(taskContext)
+
+    // Guard 2: sampling — honour the sampling decision already made by the driver.
+    // The W3C traceparent flags byte encodes the sampling bit. If the driver did not
+    // sample this trace (flags = 00), don't create an executor span either.
+    // This keeps sampling consistent across the driver→executor boundary.
+    val parentSpanContext = io.opentelemetry.api.trace.Span.fromContext(parentContext).getSpanContext
+    if (parentSpanContext.isValid && !parentSpanContext.isSampled) {
+      logger.debug(s"[Flare] Task not sampled (inherited from driver), partition=${taskContext.partitionId()}")
+      taskState.set(None)
+      return
+    }
+
+    // Guard 3: maxSpansPerTrace circuit breaker — check BEFORE incrementing so
+    // suppressed tasks don't consume counter slots.
+    if (spanCount.get() >= config.maxSpansPerTrace) {
+      if (!maxSpansWarned) {
+        logger.warn(s"[Flare] Executor span limit reached (${config.maxSpansPerTrace}). " +
+          s"Suppressing further task spans. Increase FLARE_MAX_SPANS_PER_TRACE to raise the limit.")
+        maxSpansWarned = true
+      }
+      taskState.set(None)
+      return
+    }
+    val currentCount = spanCount.incrementAndGet()
+
+    val tracer = GlobalOpenTelemetry.getTracer("io.flare.spark", BuildInfo.version)
+
+    val spanBuilder = tracer
+      .spanBuilder("spark.task.executor")
+      .setSpanKind(SpanKind.INTERNAL)
+      .setParent(parentContext)
+      .setLong(Task.PartitionId, taskContext.partitionId().toLong)
+      .setLong(Task.AttemptId, taskContext.attemptNumber().toLong)
+
+    // Task.Speculative: attemptNumber > 0 means retry, not necessarily speculative.
+    // Spark's public TaskContext API does not expose a speculative flag directly.
+    // We record the attempt number and leave the speculative attribute unset
+    // rather than conflating retries with speculation.
+
+    // tracesTaskDetails = granularity ALL — add stageId
+    if (config.tracesTaskDetails) {
+      spanBuilder.setLong(Stage.Id, taskContext.stageId().toLong)
+    }
+
+    val span  = spanBuilder.startSpan()
+    val scope = span.makeCurrent()
+    taskState.set(Some((span, scope)))
+
+    logger.debug(s"[Flare] Task span started, partition=${taskContext.partitionId()}, " +
+      s"traceId=${span.getSpanContext.getTraceId}, spanCount=$currentCount")
+  }
+
+  override def onTaskSucceeded(): Unit = endTask(success = true, reason = None)
+
+  override def onTaskFailed(failureReason: TaskFailedReason): Unit =
+    endTask(success = false, reason = Some(failureReason.toString))
+
+  private def endTask(success: Boolean, reason: Option[String]): Unit = {
+    Option(taskState.get()).flatten.foreach { case (span, scope) =>
+      try {
+        if (success) {
+          span.setStatus(StatusCode.OK)
+          span.setAttribute(Task.Result, "SUCCESS")
+        } else {
+          span.setStatus(StatusCode.ERROR, reason.getOrElse("Task failed"))
+          span.setAttribute(Task.Result, "FAILED")
+          reason.foreach(r => span.setAttribute(Error.Message, r))
+        }
+      } finally {
+        scope.close()
+        span.end()
+        taskState.remove()
+      }
+    }
+  }
+
+  override def shutdown(): Unit = {
+    logger.info(s"[Flare] Executor plugin shutdown (total spans created: ${spanCount.get()})")
+  }
+}

--- a/src/main/scala/io/flare/spark/plugin/FlareSparkPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareSparkPlugin.scala
@@ -1,0 +1,15 @@
+package io.flare.spark.plugin
+
+import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, SparkPlugin}
+
+/**
+ * Top-level SparkPlugin entry point. Returns FlareDriverPlugin for the driver JVM
+ * and FlareExecutorPlugin for each executor JVM.
+ *
+ * Register via spark.plugins=io.flare.spark.plugin.FlareSparkPlugin
+ * or let the pre-wired spark-defaults.conf in the Docker image handle it.
+ */
+class FlareSparkPlugin extends SparkPlugin {
+  override def driverPlugin(): DriverPlugin = new FlareDriverPlugin()
+  override def executorPlugin(): ExecutorPlugin = new FlareExecutorPlugin()
+}

--- a/src/main/scala/io/flare/spark/propagation/LocalPropertyPropagator.scala
+++ b/src/main/scala/io/flare/spark/propagation/LocalPropertyPropagator.scala
@@ -1,0 +1,76 @@
+package io.flare.spark.propagation
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.context.propagation.{TextMapGetter, TextMapSetter}
+import io.opentelemetry.context.{Context => OtelContext}
+import org.apache.spark.SparkContext
+import org.apache.spark.TaskContext
+import org.slf4j.LoggerFactory
+
+import java.{util => ju}
+
+/**
+ * Injects and extracts W3C traceparent/tracestate via Spark's LocalProperty mechanism.
+ *
+ * Injection (driver side): writes to SparkContext.setLocalProperty().
+ * The local property is serialized into TaskDescription and deserialized on the executor JVM.
+ *
+ * Extraction (executor side): reads from TaskContext.getLocalProperty().
+ *
+ * IMPORTANT: Use W3C format exclusively. Do NOT use custom traceId-spanId-flags serialization.
+ * The property key is the literal string "traceparent" (and "tracestate" if present).
+ */
+object LocalPropertyPropagator {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  // W3C standard header names, used as local property keys
+  private val TraceparentKey = "traceparent"
+  private val TracestateKey  = "tracestate"
+
+  /**
+   * Inject current OTEL context into Spark local properties.
+   * Call on the driver before submitting tasks.
+   */
+  def inject(context: OtelContext, sc: SparkContext): Unit = {
+    val propagator = GlobalOpenTelemetry.getPropagators.getTextMapPropagator
+    propagator.inject(context, sc, SparkContextSetter)
+    logger.debug(s"[Flare] Injected trace context into local properties")
+  }
+
+  /**
+   * Extract OTEL parent context from Spark task local properties.
+   * Call on the executor at task start, before the task lambda runs.
+   */
+  def extract(taskContext: TaskContext): OtelContext = {
+    val propagator = GlobalOpenTelemetry.getPropagators.getTextMapPropagator
+    val parentContext = propagator.extract(OtelContext.root(), taskContext, TaskContextGetter)
+
+    if (parentContext == OtelContext.root()) {
+      logger.debug("[Flare] No trace context found in task properties")
+    } else {
+      logger.debug("[Flare] Extracted trace context from task properties")
+    }
+
+    parentContext
+  }
+
+  // ── TextMapSetter for SparkContext ─────────────────────────────────────────
+
+  private val SparkContextSetter: TextMapSetter[SparkContext] =
+    (carrier: SparkContext, key: String, value: String) => {
+      carrier.setLocalProperty(key, value)
+    }
+
+  // ── TextMapGetter for TaskContext ──────────────────────────────────────────
+
+  private val TaskContextGetter: TextMapGetter[TaskContext] =
+    new TextMapGetter[TaskContext] {
+      override def keys(carrier: TaskContext): java.lang.Iterable[String] =
+        ju.Arrays.asList(TraceparentKey, TracestateKey)
+
+      override def get(carrier: TaskContext, key: String): String =
+        if (carrier == null) null
+        else carrier.getLocalProperty(key)
+    }
+}

--- a/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
+++ b/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
@@ -1,0 +1,267 @@
+package io.flare.spark.listener
+
+import io.flare.spark.attributes.SparkAttributes._
+import io.flare.spark.config.{FlareConfig, TraceGranularity}
+import io.opentelemetry.api.trace.{SpanKind, StatusCode}
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import munit.FunSuite
+import org.apache.spark.FlareTestHelpers
+import org.apache.spark.scheduler._
+
+import scala.jdk.CollectionConverters._
+
+class TracingSparkListenerTest extends FunSuite {
+
+  // Test config — all features enabled, no filtering
+  val config: FlareConfig = FlareConfig(
+    enabled          = true,
+    granularity      = TraceGranularity.All,
+    samplingRatio    = 1.0,
+    maxSpansPerTrace = 10000,
+    slowTaskMs       = 0L,
+    retryTasksOnly   = false,
+    taskStageIds     = Set.empty,
+    taskStagePattern = None,
+  )
+
+  /**
+   * Test fixture: creates a fresh InMemorySpanExporter, SdkTracerProvider,
+   * TracingSparkListener, and a root application span. Calls the body with
+   * the listener and exporter. Closes the tracer provider in finally.
+   *
+   * Each test must call listener.shutdown() when done to flush all open spans
+   * into the exporter before asserting.
+   */
+  def withListener(body: (TracingSparkListener, InMemorySpanExporter) => Unit): Unit = {
+    val exporter = InMemorySpanExporter.create()
+    val tracerProvider = SdkTracerProvider.builder()
+      .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+      .build()
+    val tracer = tracerProvider.get("io.flare.spark.test")
+    val listener = new TracingSparkListener(tracer, config, throwOnError = true)
+
+    val appSpan = tracer.spanBuilder("spark.application")
+      .setSpanKind(SpanKind.SERVER)
+      .startSpan()
+    listener.setApplicationSpan(appSpan)
+
+    try body(listener, exporter)
+    finally tracerProvider.close()
+  }
+
+  // ── Event helpers using FlareTestHelpers for private[spark] access ──────────
+
+  def makeJobStart(jobId: Int, stageIds: Seq[Int]): SparkListenerJobStart =
+    SparkListenerJobStart(
+      jobId      = jobId,
+      time       = System.currentTimeMillis(),
+      stageInfos = stageIds.map(id => FlareTestHelpers.makeStageInfo(id, s"stage-$id")),
+      properties = new java.util.Properties(),
+    )
+
+  def makeJobEnd(jobId: Int, succeeded: Boolean): SparkListenerJobEnd =
+    SparkListenerJobEnd(
+      jobId     = jobId,
+      time      = System.currentTimeMillis(),
+      jobResult = if (succeeded) JobSucceeded else FlareTestHelpers.jobFailed(new RuntimeException("boom")),
+    )
+
+  def makeStageSubmitted(stageId: Int): SparkListenerStageSubmitted =
+    SparkListenerStageSubmitted(FlareTestHelpers.makeStageInfo(stageId, s"stage-$stageId"))
+
+  def makeStageCompleted(stageId: Int, failed: Boolean = false): SparkListenerStageCompleted = {
+    val info = FlareTestHelpers.makeStageInfo(stageId, s"stage-$stageId")
+    if (failed) info.failureReason = Some("OOM")
+    SparkListenerStageCompleted(info)
+  }
+
+  def makeStageCompletedWithMetrics(stageId: Int): SparkListenerStageCompleted = {
+    val info = FlareTestHelpers.makeStageInfo(
+      stageId, s"stage-$stageId", taskMetrics = FlareTestHelpers.emptyTaskMetrics(),
+    )
+    SparkListenerStageCompleted(info)
+  }
+
+  // ── Tests ───────────────────────────────────────────────────────────────────
+
+  test("job span is created as child of application span") {
+    withListener { (listener, exporter) =>
+      listener.onJobStart(makeJobStart(0, Seq(0)))
+      listener.onJobEnd(makeJobEnd(0, succeeded = true))
+      listener.shutdown()
+
+      val spans = exporter.getFinishedSpanItems.asScala
+      val appSpan = spans.find(_.getName == "spark.application").get
+      val jobSpan = spans.find(_.getName == "spark.job.0").get
+
+      assertEquals(jobSpan.getParentSpanId, appSpan.getSpanId)
+      assertEquals(jobSpan.getTraceId, appSpan.getTraceId)
+    }
+  }
+
+  test("stage span uses correct job parent via reverse index") {
+    withListener { (listener, exporter) =>
+      // Two concurrent jobs, each with its own stage
+      listener.onJobStart(makeJobStart(0, Seq(10)))
+      listener.onJobStart(makeJobStart(1, Seq(20)))
+
+      listener.onStageSubmitted(makeStageSubmitted(10))
+      listener.onStageSubmitted(makeStageSubmitted(20))
+
+      listener.onStageCompleted(makeStageCompleted(10))
+      listener.onStageCompleted(makeStageCompleted(20))
+      listener.onJobEnd(makeJobEnd(0, succeeded = true))
+      listener.onJobEnd(makeJobEnd(1, succeeded = true))
+      listener.shutdown()
+
+      val spans = exporter.getFinishedSpanItems.asScala
+      val job0  = spans.find(_.getName == "spark.job.0").get
+      val job1  = spans.find(_.getName == "spark.job.1").get
+      val stg10 = spans.find(_.getName == "spark.stage.10").get
+      val stg20 = spans.find(_.getName == "spark.stage.20").get
+
+      // Stage 10 must be child of job 0
+      assertEquals(stg10.getParentSpanId, job0.getSpanId)
+      // Stage 20 must be child of job 1 — NOT job 0
+      assertEquals(stg20.getParentSpanId, job1.getSpanId)
+    }
+  }
+
+  test("stage span parent falls back to application span when job has ended") {
+    withListener { (listener, exporter) =>
+      // Start and end a job, then submit a stage whose job is gone
+      listener.onJobStart(makeJobStart(0, Seq(5)))
+      listener.onJobEnd(makeJobEnd(0, succeeded = true))
+
+      // Stage 5's job (0) has ended — stageToJob entry was cleaned up.
+      // The stage should fall back to the application span as parent.
+      listener.onStageSubmitted(makeStageSubmitted(5))
+      listener.onStageCompleted(makeStageCompleted(5))
+      listener.shutdown()
+
+      val spans   = exporter.getFinishedSpanItems.asScala
+      val appSpan = spans.find(_.getName == "spark.application").get
+      val stg5    = spans.find(_.getName == "spark.stage.5").get
+
+      assertEquals(stg5.getParentSpanId, appSpan.getSpanId)
+    }
+  }
+
+  test("job span records FAILED status on JobFailed result") {
+    withListener { (listener, exporter) =>
+      listener.onJobStart(makeJobStart(0, Seq(0)))
+      listener.onJobEnd(makeJobEnd(0, succeeded = false))
+      listener.shutdown()
+
+      val spans   = exporter.getFinishedSpanItems.asScala
+      val jobSpan = spans.find(_.getName == "spark.job.0").get
+
+      assertEquals(jobSpan.getStatus.getStatusCode, StatusCode.ERROR)
+      assertEquals(
+        jobSpan.getAttributes.get(Job.Result),
+        "FAILED",
+      )
+    }
+  }
+
+  test("stage span records task metrics as attributes on completion") {
+    withListener { (listener, exporter) =>
+      listener.onJobStart(makeJobStart(0, Seq(0)))
+      listener.onStageSubmitted(makeStageSubmitted(0))
+
+      // Complete with a TaskMetrics-bearing StageInfo (metrics are zero but attributes must exist)
+      listener.onStageCompleted(makeStageCompletedWithMetrics(0))
+      listener.onJobEnd(makeJobEnd(0, succeeded = true))
+      listener.shutdown()
+
+      val spans    = exporter.getFinishedSpanItems.asScala
+      val stgSpan  = spans.find(_.getName == "spark.stage.0").get
+      val attrs    = stgSpan.getAttributes
+
+      // Verify metrics attributes are present (values are 0 from a fresh TaskMetrics)
+      assert(attrs.get(Stage.ExecutorRunTime) != null, "executorRunTime attribute missing")
+      assert(attrs.get(Stage.ExecutorCpuTime) != null, "executorCpuTime attribute missing")
+      assert(attrs.get(Stage.InputBytes) != null, "inputBytes attribute missing")
+      assert(attrs.get(Stage.OutputBytes) != null, "outputBytes attribute missing")
+      assert(attrs.get(Stage.ShuffleReadBytes) != null, "shuffleReadBytes attribute missing")
+      assert(attrs.get(Stage.ShuffleWriteBytes) != null, "shuffleWriteBytes attribute missing")
+    }
+  }
+
+  test("stage span records failure reason on failed stage") {
+    withListener { (listener, exporter) =>
+      listener.onJobStart(makeJobStart(0, Seq(0)))
+      listener.onStageSubmitted(makeStageSubmitted(0))
+      listener.onStageCompleted(makeStageCompleted(0, failed = true))
+      listener.onJobEnd(makeJobEnd(0, succeeded = true))
+      listener.shutdown()
+
+      val spans   = exporter.getFinishedSpanItems.asScala
+      val stgSpan = spans.find(_.getName == "spark.stage.0").get
+
+      assertEquals(stgSpan.getStatus.getStatusCode, StatusCode.ERROR)
+      assertEquals(stgSpan.getAttributes.get(Stage.FailureReason), "OOM")
+    }
+  }
+
+  test("shutdown ends all open spans without throwing") {
+    withListener { (listener, exporter) =>
+      // Start a job and stage, do NOT end them
+      listener.onJobStart(makeJobStart(0, Seq(0)))
+      listener.onStageSubmitted(makeStageSubmitted(0))
+
+      // Shutdown should end all open spans without throwing
+      listener.shutdown()
+
+      val spans = exporter.getFinishedSpanItems.asScala
+
+      // Application, job, and stage spans should all be present (ended by shutdown)
+      assert(spans.exists(_.getName == "spark.application"), "application span missing")
+      assert(spans.exists(_.getName == "spark.job.0"), "job span missing")
+      assert(spans.exists(_.getName == "spark.stage.0"), "stage span missing")
+    }
+  }
+
+  test("concurrent jobs do not interfere with stage attribution") {
+    withListener { (listener, exporter) =>
+      // Three concurrent jobs with interleaved stage submissions
+      listener.onJobStart(makeJobStart(0, Seq(100, 101)))
+      listener.onJobStart(makeJobStart(1, Seq(200)))
+      listener.onJobStart(makeJobStart(2, Seq(300, 301)))
+
+      // Stages submitted in non-sequential order
+      listener.onStageSubmitted(makeStageSubmitted(200))
+      listener.onStageSubmitted(makeStageSubmitted(100))
+      listener.onStageSubmitted(makeStageSubmitted(301))
+      listener.onStageSubmitted(makeStageSubmitted(101))
+      listener.onStageSubmitted(makeStageSubmitted(300))
+
+      // Complete all stages and jobs
+      Seq(100, 101, 200, 300, 301).foreach(id => listener.onStageCompleted(makeStageCompleted(id)))
+      Seq(0, 1, 2).foreach(id => listener.onJobEnd(makeJobEnd(id, succeeded = true)))
+      listener.shutdown()
+
+      val spans  = exporter.getFinishedSpanItems.asScala
+      val job0   = spans.find(_.getName == "spark.job.0").get
+      val job1   = spans.find(_.getName == "spark.job.1").get
+      val job2   = spans.find(_.getName == "spark.job.2").get
+
+      val stg100 = spans.find(_.getName == "spark.stage.100").get
+      val stg101 = spans.find(_.getName == "spark.stage.101").get
+      val stg200 = spans.find(_.getName == "spark.stage.200").get
+      val stg300 = spans.find(_.getName == "spark.stage.300").get
+      val stg301 = spans.find(_.getName == "spark.stage.301").get
+
+      // Job 0 stages
+      assertEquals(stg100.getParentSpanId, job0.getSpanId)
+      assertEquals(stg101.getParentSpanId, job0.getSpanId)
+      // Job 1 stage
+      assertEquals(stg200.getParentSpanId, job1.getSpanId)
+      // Job 2 stages
+      assertEquals(stg300.getParentSpanId, job2.getSpanId)
+      assertEquals(stg301.getParentSpanId, job2.getSpanId)
+    }
+  }
+}

--- a/src/test/scala/org/apache/spark/FlareTestHelpers.scala
+++ b/src/test/scala/org/apache/spark/FlareTestHelpers.scala
@@ -1,0 +1,26 @@
+package org.apache.spark
+
+import org.apache.spark.executor.TaskMetrics
+import org.apache.spark.scheduler.{JobFailed, JobResult, StageInfo}
+
+/**
+ * Test helpers in the org.apache.spark package to access private[spark] members.
+ * This is a standard pattern for testing Spark internals.
+ */
+object FlareTestHelpers {
+
+  def emptyTaskMetrics(): TaskMetrics = new TaskMetrics()
+
+  def jobFailed(exception: Exception): JobResult = JobFailed(exception)
+
+  def makeStageInfo(
+    stageId:     Int,
+    name:        String,
+    numTasks:    Int    = 4,
+    taskMetrics: TaskMetrics = null,
+  ): StageInfo =
+    new StageInfo(
+      stageId, 0, name, numTasks, Nil, Nil, "",
+      taskMetrics, Nil, None, 0, false, 0,
+    )
+}


### PR DESCRIPTION
Closes #1

## Summary

- Full span hierarchy: `spark.application` → `spark.job` → `spark.stage` → `spark.task.executor`
- W3C `traceparent` propagation via `SparkContext.setLocalProperty()` → `TaskContext.getLocalProperty()`
- `FlareSparkPlugin` with `FlareDriverPlugin` (app span, listener, traceparent injection) and `FlareExecutorPlugin` (task spans on executor JVM)
- `TracingSparkListener` with correct stage→job attribution, concurrent job safety, SQL spans, shutdown cleanup
- `FlareConfig` with env var + system property resolution, granularity/sampling/slow-task/retry-only controls
- Docker dev stack: Spark master + 2 workers + history, Alloy → Tempo → Grafana
- 3 example jobs (SimpleJob, SkewedJob, PipelineJob) using pure DataFrame API for Spark 3.5/4.0 compatibility
- 8 unit tests via munit + `InMemorySpanExporter`

## Test plan
- [x] `sbt test` — all 8 tests pass
- [x] `sbt assembly` + `sbt "examples/assembly"` — clean build
- [x] `docker compose up -d` — all 7 containers healthy
- [x] SkewedJob end-to-end: 602 task spans from 2 executors visible in Tempo
- [x] Grafana at localhost:3000 shows full trace with `flare-driver` and `flare-executor` services