### PR TITLE
Stage filtering, task metrics, MDC enrichment, shutdown flush

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF for shell scripts — CRLF breaks bind-mounted entrypoints in Docker
+*.sh text eol=lf

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,9 @@ lazy val root = (project in file("."))
     libraryDependencies ++= otelBundled ++ otelProvided ++ byteBuddyCompileOnly ++ Seq(
       "org.apache.spark" %% "spark-core" % sparkBuildVersion % "provided",
       "org.apache.spark" %% "spark-sql"  % sparkBuildVersion % "provided",
-      "org.slf4j"         % "slf4j-api"  % slf4jVersion      % "provided",
+      "org.slf4j"                % "slf4j-api"  % slf4jVersion % "provided",
+      // log4j-api is provided transitively by spark-core — no explicit dep needed.
+      // MdcEnricher references ThreadContext at compile time; Spark's log4j-api satisfies it.
     ) ++ testDeps(sparkBuildVersion),
 
     // SPI files — do not let assembly deduplicate these

--- a/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
+++ b/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
@@ -43,6 +43,14 @@ object SparkAttributes {
     val Speculative = AttributeKey.booleanKey("spark.task.speculative")
     val Result      = AttributeKey.stringKey("spark.task.result")
     val Locality    = AttributeKey.stringKey("spark.task.locality")
+    // v0.2 — task-level metrics (recorded at task end from TaskMetrics)
+    val ShuffleReadBytes  = AttributeKey.longKey("spark.task.shuffle.read_bytes")
+    val ShuffleWriteBytes = AttributeKey.longKey("spark.task.shuffle.write_bytes")
+    val PeakMemory        = AttributeKey.longKey("spark.task.peak_memory_bytes")
+    val InputBytes        = AttributeKey.longKey("spark.task.input.bytes")
+    val OutputBytes       = AttributeKey.longKey("spark.task.output.bytes")
+    val DurationMs        = AttributeKey.longKey("spark.task.duration_ms")
+    val SqlExecutionId    = AttributeKey.longKey("spark.task.sql.execution_id")
   }
 
   // OTEL semantic conventions

--- a/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
@@ -20,18 +20,13 @@ import java.util.concurrent.atomic.AtomicLong
  * Executor-side plugin that restores OTEL context from Spark local properties
  * and creates real executor-side task spans with the correct parent.
  *
- * Respects FLARE_TRACE_GRANULARITY — task spans are only created when granularity
- * is `tasks` or `all`. With `jobs` or `stages`, onTaskStart is a no-op.
- *
- * Respects FLARE_SAMPLING_RATIO — samples consistently per trace by checking
- * the sampling bit already set in the incoming W3C traceparent. If the driver
- * sampled the trace, the executor follows. No independent sampling decision here.
- *
- * Respects FLARE_MAX_SPANS_PER_TRACE — once the per-executor span counter
- * exceeds the limit, new task spans are suppressed and a warning is logged once.
- *
- * Uses ThreadLocal because executor threads are pooled and run tasks serially
- * per thread, but multiple threads may run tasks concurrently on one executor.
+ * v0.2 additions:
+ * - Stage-level task filtering via FLARE_TASK_STAGES / FLARE_TASK_STAGE_PATTERN
+ * - Slow task filter via FLARE_SLOW_TASK_MS (drop spans for fast tasks)
+ * - Retry-only filter via FLARE_RETRY_TASKS_ONLY
+ * - Task span metrics: shuffle bytes, peak memory, SQL execution ID
+ * - Log MDC enrichment: trace_id/span_id injected into Log4j 2 ThreadContext
+ * - Shutdown flush: force-flush TracerProvider on executor shutdown (K8s SIGTERM)
  */
 class FlareExecutorPlugin extends ExecutorPlugin {
 
@@ -42,8 +37,6 @@ class FlareExecutorPlugin extends ExecutorPlugin {
   private var config: FlareConfig = _
 
   // Counts spans created on this executor JVM across all tasks.
-  // Reset is not possible mid-job, so this is a conservative circuit breaker
-  // that prevents unbounded span growth on large jobs.
   private val spanCount = new AtomicLong(0L)
 
   // Set to true once the maxSpansPerTrace warning has been logged, to avoid log spam
@@ -53,11 +46,13 @@ class FlareExecutorPlugin extends ExecutorPlugin {
   // None means this task was not sampled or granularity suppressed it.
   private val taskState = new ThreadLocal[Option[(Span, Scope)]]()
 
+  // Nanosecond timestamp at task start — used for duration_ms attribute and slow task filter.
+  private val taskStartNanos = new ThreadLocal[Long]()
+
   override def init(ctx: PluginContext, extraConf: ju.Map[String, String]): Unit = {
     config = try FlareConfig.load() catch {
       case e: IllegalArgumentException =>
         logger.error(s"[Flare] Configuration error — executor task spans disabled: ${e.getMessage}")
-        // Fall back to a disabled config so onTaskStart is a no-op
         FlareConfig(enabled = false, granularity = TraceGranularity.Stages,
           samplingRatio = 0.0, maxSpansPerTrace = 0, slowTaskMs = 0L,
           retryTasksOnly = false, taskStageIds = Set.empty, taskStagePattern = None)
@@ -68,12 +63,6 @@ class FlareExecutorPlugin extends ExecutorPlugin {
   }
 
   override def onTaskStart(): Unit = {
-    // Guard 1: granularity — tasks must be enabled
-    if (!config.tracesTasks) {
-      taskState.set(None)
-      return
-    }
-
     val taskContext = TaskContext.get()
     if (taskContext == null) {
       logger.warn("[Flare] onTaskStart called with null TaskContext")
@@ -81,12 +70,21 @@ class FlareExecutorPlugin extends ExecutorPlugin {
       return
     }
 
+    // Guard 1: granularity + stage/retry filters (replaces simple tracesTasks check).
+    // slowTaskMs is deferred to endTask since duration is not known at start.
+    if (!config.shouldTraceTask(
+      attemptNumber = taskContext.attemptNumber(),
+      speculative   = false, // TaskContext does not expose speculative flag
+      stageId       = taskContext.stageId(),
+      stageName     = "",    // stage name not available on executor until Phase 2
+    )) {
+      taskState.set(None)
+      return
+    }
+
     val parentContext = LocalPropertyPropagator.extract(taskContext)
 
     // Guard 2: sampling — honour the sampling decision already made by the driver.
-    // The W3C traceparent flags byte encodes the sampling bit. If the driver did not
-    // sample this trace (flags = 00), don't create an executor span either.
-    // This keeps sampling consistent across the driver→executor boundary.
     val parentSpanContext = io.opentelemetry.api.trace.Span.fromContext(parentContext).getSpanContext
     if (parentSpanContext.isValid && !parentSpanContext.isSampled) {
       logger.debug(s"[Flare] Task not sampled (inherited from driver), partition=${taskContext.partitionId()}")
@@ -94,8 +92,7 @@ class FlareExecutorPlugin extends ExecutorPlugin {
       return
     }
 
-    // Guard 3: maxSpansPerTrace circuit breaker — check BEFORE incrementing so
-    // suppressed tasks don't consume counter slots.
+    // Guard 3: maxSpansPerTrace circuit breaker — check BEFORE incrementing.
     if (spanCount.get() >= config.maxSpansPerTrace) {
       if (!maxSpansWarned) {
         logger.warn(s"[Flare] Executor span limit reached (${config.maxSpansPerTrace}). " +
@@ -116,11 +113,6 @@ class FlareExecutorPlugin extends ExecutorPlugin {
       .setLong(Task.PartitionId, taskContext.partitionId().toLong)
       .setLong(Task.AttemptId, taskContext.attemptNumber().toLong)
 
-    // Task.Speculative: attemptNumber > 0 means retry, not necessarily speculative.
-    // Spark's public TaskContext API does not expose a speculative flag directly.
-    // We record the attempt number and leave the speculative attribute unset
-    // rather than conflating retries with speculation.
-
     // tracesTaskDetails = granularity ALL — add stageId
     if (config.tracesTaskDetails) {
       spanBuilder.setLong(Stage.Id, taskContext.stageId().toLong)
@@ -129,6 +121,10 @@ class FlareExecutorPlugin extends ExecutorPlugin {
     val span  = spanBuilder.startSpan()
     val scope = span.makeCurrent()
     taskState.set(Some((span, scope)))
+    taskStartNanos.set(System.nanoTime())
+
+    // MDC enrichment — inject trace_id/span_id into Log4j 2 ThreadContext for log correlation
+    MdcEnricher.put(span.getSpanContext.getTraceId, span.getSpanContext.getSpanId)
 
     logger.debug(s"[Flare] Task span started, partition=${taskContext.partitionId()}, " +
       s"traceId=${span.getSpanContext.getTraceId}, spanCount=$currentCount")
@@ -142,6 +138,21 @@ class FlareExecutorPlugin extends ExecutorPlugin {
   private def endTask(success: Boolean, reason: Option[String]): Unit = {
     Option(taskState.get()).flatten.foreach { case (span, scope) =>
       try {
+        // Compute duration for slow task filter and duration attribute
+        val startNanos = taskStartNanos.get()
+        val durationMs = if (startNanos > 0) (System.nanoTime() - startNanos) / 1000000L else -1L
+
+        // Slow task filter — drop span if task was faster than threshold.
+        // Close scope but do NOT end span — unended spans are not exported by BatchSpanProcessor.
+        if (config.slowTaskMs > 0 && durationMs >= 0 && durationMs < config.slowTaskMs) {
+          MdcEnricher.remove()
+          scope.close()
+          taskState.remove()
+          taskStartNanos.remove()
+          return
+        }
+
+        // Set status
         if (success) {
           span.setStatus(StatusCode.OK)
           span.setAttribute(Task.Result, "SUCCESS")
@@ -150,15 +161,96 @@ class FlareExecutorPlugin extends ExecutorPlugin {
           span.setAttribute(Task.Result, "FAILED")
           reason.foreach(r => span.setAttribute(Error.Message, r))
         }
+
+        // Record task duration
+        if (durationMs >= 0) {
+          span.setLong(Task.DurationMs, durationMs)
+        }
+
+        // Record task metrics from TaskMetrics (only fully populated at task end)
+        val taskContext = TaskContext.get()
+        if (taskContext != null) {
+          try {
+            val m = taskContext.taskMetrics()
+            span.setLong(Task.ShuffleReadBytes, m.shuffleReadMetrics.totalBytesRead)
+            span.setLong(Task.ShuffleWriteBytes, m.shuffleWriteMetrics.bytesWritten)
+            span.setLong(Task.PeakMemory, m.peakExecutionMemory)
+            span.setLong(Task.InputBytes, m.inputMetrics.bytesRead)
+            span.setLong(Task.OutputBytes, m.outputMetrics.bytesWritten)
+          } catch {
+            case _: Exception => // TaskMetrics may throw in barrier mode — skip gracefully
+          }
+
+          // SQL execution ID from local properties
+          Option(taskContext.getLocalProperty("spark.sql.execution.id"))
+            .flatMap(_.toLongOption)
+            .foreach(id => span.setLong(Task.SqlExecutionId, id))
+        }
       } finally {
+        MdcEnricher.remove()
         scope.close()
         span.end()
         taskState.remove()
+        taskStartNanos.remove()
       }
     }
   }
 
   override def shutdown(): Unit = {
     logger.info(s"[Flare] Executor plugin shutdown (total spans created: ${spanCount.get()})")
+
+    // End any in-flight task span on this thread (e.g. K8s SIGTERM during task execution)
+    Option(taskState.get()).flatten.foreach { case (span, scope) =>
+      MdcEnricher.remove()
+      span.setStatus(StatusCode.ERROR, "Executor shutdown before task completed")
+      span.setAttribute(Task.Result, "SHUTDOWN")
+      scope.close()
+      span.end()
+      taskState.remove()
+    }
+
+    // Force-flush TracerProvider to push buffered spans before JVM exits.
+    // The SDK classes live in the agent classloader — catch NoClassDefFoundError
+    // if they're not visible from the app classloader.
+    try {
+      GlobalOpenTelemetry.get() match {
+        case sdk: io.opentelemetry.sdk.OpenTelemetrySdk =>
+          sdk.getSdkTracerProvider.forceFlush().join(5, ju.concurrent.TimeUnit.SECONDS)
+          logger.info("[Flare] Forced flush of TracerProvider completed")
+        case _ => ()
+      }
+    } catch {
+      case _: NoClassDefFoundError =>
+        logger.debug("[Flare] SDK classes not accessible, relying on agent shutdown hook")
+      case e: Exception =>
+        logger.warn(s"[Flare] Error during shutdown flush: ${e.getMessage}")
+    }
   }
+}
+
+/**
+ * MDC enrichment for Log4j 2 ThreadContext.
+ * Injects trace_id and span_id so executor log lines can be correlated with traces in Grafana.
+ * Falls back to no-op if Log4j 2 is not on the classpath.
+ */
+private[plugin] object MdcEnricher {
+
+  private val log4j2Available: Boolean = try {
+    Class.forName("org.apache.logging.log4j.ThreadContext")
+    true
+  } catch {
+    case _: ClassNotFoundException => false
+  }
+
+  def put(traceId: String, spanId: String): Unit =
+    if (log4j2Available) {
+      org.apache.logging.log4j.ThreadContext.put("trace_id", traceId)
+      org.apache.logging.log4j.ThreadContext.put("span_id", spanId)
+    }
+
+  def remove(): Unit =
+    if (log4j2Available) {
+      org.apache.logging.log4j.ThreadContext.remove("trace_id")
+      org.apache.logging.log4j.ThreadContext.remove("span_id")
+    }
 }

--- a/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
@@ -60,6 +60,15 @@ class FlareExecutorPlugin extends ExecutorPlugin {
     logger.info(s"[Flare] Executor plugin initialized (granularity=${config.granularity}, " +
       s"sampling=${config.samplingRatio}, maxSpans=${config.maxSpansPerTrace}, " +
       s"taskTracing=${config.tracesTasks})")
+
+    // Stage name is not available on the executor in Phase 1 (ExecutorPlugin has no access to
+    // stage metadata — only stageId from TaskContext). Warn if someone configures the pattern
+    // filter so they don't silently get no matches.
+    if (config.taskStagePattern.isDefined) {
+      logger.warn("[Flare] FLARE_TASK_STAGE_PATTERN is configured but stage names are not " +
+        "available on executor in Phase 1. The pattern filter will have no effect — use " +
+        "FLARE_TASK_STAGES (stage IDs) instead, or wait for Phase 2 ByteBuddy instrumentation.")
+    }
   }
 
   override def onTaskStart(): Unit = {
@@ -74,7 +83,9 @@ class FlareExecutorPlugin extends ExecutorPlugin {
     // slowTaskMs is deferred to endTask since duration is not known at start.
     if (!config.shouldTraceTask(
       attemptNumber = taskContext.attemptNumber(),
-      speculative   = false, // TaskContext does not expose speculative flag
+      speculative   = false, // TaskContext does not expose speculative flag directly.
+                             // Speculative tasks have attemptNumber > 0, so the retry filter
+                             // handles them. True speculative detection needs Phase 2 ByteBuddy.
       stageId       = taskContext.stageId(),
       stageName     = "",    // stage name not available on executor until Phase 2
     )) {
@@ -85,6 +96,10 @@ class FlareExecutorPlugin extends ExecutorPlugin {
     val parentContext = LocalPropertyPropagator.extract(taskContext)
 
     // Guard 2: sampling — honour the sampling decision already made by the driver.
+    // The driver's TracerProvider applies head-based sampling when creating the application span.
+    // That decision propagates via traceparent flags. If the parent is valid but not sampled,
+    // we must not create child spans — otherwise the executor generates orphan spans that the
+    // backend can't stitch into a trace.
     val parentSpanContext = io.opentelemetry.api.trace.Span.fromContext(parentContext).getSpanContext
     if (parentSpanContext.isValid && !parentSpanContext.isSampled) {
       logger.debug(s"[Flare] Task not sampled (inherited from driver), partition=${taskContext.partitionId()}")
@@ -143,10 +158,17 @@ class FlareExecutorPlugin extends ExecutorPlugin {
         val durationMs = if (startNanos > 0) (System.nanoTime() - startNanos) / 1000000L else -1L
 
         // Slow task filter — drop span if task was faster than threshold.
-        // Close scope but do NOT end span — unended spans are not exported by BatchSpanProcessor.
+        // We cannot avoid starting the span (duration unknown at start), so we abandon it here.
+        // Calling span.end() would export a span we want to suppress. Instead we close the scope
+        // and leave the span unended — BatchSpanProcessor only exports ended spans.
+        // Tradeoff: the SDK's internal SdkSpan object remains allocated until GC reclaims it.
+        // On jobs with many fast tasks (e.g. thousands below threshold) this is transient memory
+        // pressure proportional to concurrent executor threads, not total tasks — each ThreadLocal
+        // is overwritten on the next task. Acceptable for the filtering benefit.
         if (config.slowTaskMs > 0 && durationMs >= 0 && durationMs < config.slowTaskMs) {
           MdcEnricher.remove()
           scope.close()
+          spanCount.decrementAndGet() // reclaim slot — this span won't be exported
           taskState.remove()
           taskStartNanos.remove()
           return

--- a/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
@@ -42,9 +42,11 @@ class FlareExecutorPlugin extends ExecutorPlugin {
   // Set to true once the maxSpansPerTrace warning has been logged, to avoid log spam
   @volatile private var maxSpansWarned = false
 
-  // ThreadLocal holds the active (span, scope) for the current task on this thread.
+  // ThreadLocal holds the active (span, scope, taskContext) for the current task on this thread.
   // None means this task was not sampled or granularity suppressed it.
-  private val taskState = new ThreadLocal[Option[(Span, Scope)]]()
+  // TaskContext is captured at onTaskStart because Spark 4.0 clears TaskContext.get() before
+  // onTaskSucceeded/onTaskFailed fires, so we can't rely on it in endTask.
+  private val taskState = new ThreadLocal[Option[(Span, Scope, TaskContext)]]()
 
   // Nanosecond timestamp at task start — used for duration_ms attribute and slow task filter.
   private val taskStartNanos = new ThreadLocal[Long]()
@@ -135,7 +137,7 @@ class FlareExecutorPlugin extends ExecutorPlugin {
 
     val span  = spanBuilder.startSpan()
     val scope = span.makeCurrent()
-    taskState.set(Some((span, scope)))
+    taskState.set(Some((span, scope, taskContext)))
     taskStartNanos.set(System.nanoTime())
 
     // MDC enrichment — inject trace_id/span_id into Log4j 2 ThreadContext for log correlation
@@ -151,7 +153,7 @@ class FlareExecutorPlugin extends ExecutorPlugin {
     endTask(success = false, reason = Some(failureReason.toString))
 
   private def endTask(success: Boolean, reason: Option[String]): Unit = {
-    Option(taskState.get()).flatten.foreach { case (span, scope) =>
+    Option(taskState.get()).flatten.foreach { case (span, scope, capturedTaskContext) =>
       try {
         // Compute duration for slow task filter and duration attribute
         val startNanos = taskStartNanos.get()
@@ -189,25 +191,27 @@ class FlareExecutorPlugin extends ExecutorPlugin {
           span.setLong(Task.DurationMs, durationMs)
         }
 
-        // Record task metrics from TaskMetrics (only fully populated at task end)
-        val taskContext = TaskContext.get()
-        if (taskContext != null) {
-          try {
-            val m = taskContext.taskMetrics()
-            span.setLong(Task.ShuffleReadBytes, m.shuffleReadMetrics.totalBytesRead)
-            span.setLong(Task.ShuffleWriteBytes, m.shuffleWriteMetrics.bytesWritten)
-            span.setLong(Task.PeakMemory, m.peakExecutionMemory)
-            span.setLong(Task.InputBytes, m.inputMetrics.bytesRead)
-            span.setLong(Task.OutputBytes, m.outputMetrics.bytesWritten)
-          } catch {
-            case _: Exception => // TaskMetrics may throw in barrier mode — skip gracefully
-          }
-
-          // SQL execution ID from local properties
-          Option(taskContext.getLocalProperty("spark.sql.execution.id"))
-            .flatMap(_.toLongOption)
-            .foreach(id => span.setLong(Task.SqlExecutionId, id))
+        // Record task metrics from TaskMetrics (only fully populated at task end).
+        // TaskContext is captured at onTaskStart because Spark 4.0 clears TaskContext.get()
+        // before onTaskSucceeded/onTaskFailed fires (unlike Spark 3.x).
+        try {
+          val m = capturedTaskContext.taskMetrics()
+          span.setLong(Task.ShuffleReadBytes, m.shuffleReadMetrics.totalBytesRead)
+          span.setLong(Task.ShuffleWriteBytes, m.shuffleWriteMetrics.bytesWritten)
+          span.setLong(Task.PeakMemory, m.peakExecutionMemory)
+          span.setLong(Task.InputBytes, m.inputMetrics.bytesRead)
+          span.setLong(Task.OutputBytes, m.outputMetrics.bytesWritten)
+        } catch {
+          // TaskMetrics is private[spark] — may throw IllegalAccessError from outside
+          // org.apache.spark, or fail in barrier mode. Log once for diagnosis.
+          case e: Throwable =>
+            logger.debug(s"[Flare] Could not read TaskMetrics: ${e.getClass.getSimpleName}: ${e.getMessage}")
         }
+
+        // SQL execution ID from local properties (captured context still has properties)
+        Option(capturedTaskContext.getLocalProperty("spark.sql.execution.id"))
+          .flatMap(_.toLongOption)
+          .foreach(id => span.setLong(Task.SqlExecutionId, id))
       } finally {
         MdcEnricher.remove()
         scope.close()
@@ -222,7 +226,7 @@ class FlareExecutorPlugin extends ExecutorPlugin {
     logger.info(s"[Flare] Executor plugin shutdown (total spans created: ${spanCount.get()})")
 
     // End any in-flight task span on this thread (e.g. K8s SIGTERM during task execution)
-    Option(taskState.get()).flatten.foreach { case (span, scope) =>
+    Option(taskState.get()).flatten.foreach { case (span, scope, _) =>
       MdcEnricher.remove()
       span.setStatus(StatusCode.ERROR, "Executor shutdown before task completed")
       span.setAttribute(Task.Result, "SHUTDOWN")

--- a/src/test/scala/io/flare/spark/config/FlareConfigTest.scala
+++ b/src/test/scala/io/flare/spark/config/FlareConfigTest.scala
@@ -1,0 +1,192 @@
+package io.flare.spark.config
+
+import munit.FunSuite
+
+class FlareConfigTest extends FunSuite {
+
+  // ── Helper: build configs with specific filters ────────────────────────────
+
+  private def baseConfig(
+    granularity:    TraceGranularity = TraceGranularity.Tasks,
+    retryTasksOnly: Boolean = false,
+    slowTaskMs:     Long = 0L,
+    taskStageIds:   Set[Int] = Set.empty,
+    taskStagePattern: Option[scala.util.matching.Regex] = None,
+  ): FlareConfig =
+    FlareConfig(
+      enabled          = true,
+      granularity      = granularity,
+      samplingRatio    = 1.0,
+      maxSpansPerTrace = 10000,
+      slowTaskMs       = slowTaskMs,
+      retryTasksOnly   = retryTasksOnly,
+      taskStageIds     = taskStageIds,
+      taskStagePattern = taskStagePattern,
+    )
+
+  // ── shouldTraceTask tests ──────────────────────────────────────────────────
+
+  test("shouldTraceTask passes when no filters configured") {
+    val config = baseConfig()
+    assert(config.shouldTraceTask(attemptNumber = 0, speculative = false))
+  }
+
+  test("shouldTraceTask returns false when granularity is Stages") {
+    val config = baseConfig(granularity = TraceGranularity.Stages)
+    assert(!config.shouldTraceTask(attemptNumber = 0, speculative = false))
+  }
+
+  test("shouldTraceTask returns false when granularity is Jobs") {
+    val config = baseConfig(granularity = TraceGranularity.Jobs)
+    assert(!config.shouldTraceTask(attemptNumber = 0, speculative = false))
+  }
+
+  test("shouldTraceTask filters by stage ID — blocks non-matching") {
+    val config = baseConfig(taskStageIds = Set(7, 12))
+    assert(!config.shouldTraceTask(attemptNumber = 0, speculative = false, stageId = 5))
+  }
+
+  test("shouldTraceTask filters by stage ID — passes matching") {
+    val config = baseConfig(taskStageIds = Set(7, 12))
+    assert(config.shouldTraceTask(attemptNumber = 0, speculative = false, stageId = 12))
+  }
+
+  test("shouldTraceTask skips stage ID filter when stageId is -1") {
+    val config = baseConfig(taskStageIds = Set(7, 12))
+    assert(config.shouldTraceTask(attemptNumber = 0, speculative = false, stageId = -1))
+  }
+
+  test("shouldTraceTask filters by stage name pattern — blocks non-matching") {
+    val config = baseConfig(taskStagePattern = Some(".*shuffle.*".r))
+    assert(!config.shouldTraceTask(
+      attemptNumber = 0, speculative = false, stageName = "mapPartitions"))
+  }
+
+  test("shouldTraceTask filters by stage name pattern — passes matching") {
+    val config = baseConfig(taskStagePattern = Some(".*shuffle.*".r))
+    assert(config.shouldTraceTask(
+      attemptNumber = 0, speculative = false, stageName = "shuffle read at MyJob.scala:42"))
+  }
+
+  test("shouldTraceTask skips pattern check when stageName is empty") {
+    val config = baseConfig(taskStagePattern = Some(".*shuffle.*".r))
+    assert(config.shouldTraceTask(attemptNumber = 0, speculative = false, stageName = ""))
+  }
+
+  test("shouldTraceTask retryOnly blocks attempt 0 non-speculative") {
+    val config = baseConfig(retryTasksOnly = true)
+    assert(!config.shouldTraceTask(attemptNumber = 0, speculative = false))
+  }
+
+  test("shouldTraceTask retryOnly passes attempt > 0") {
+    val config = baseConfig(retryTasksOnly = true)
+    assert(config.shouldTraceTask(attemptNumber = 1, speculative = false))
+  }
+
+  test("shouldTraceTask retryOnly passes speculative task") {
+    val config = baseConfig(retryTasksOnly = true)
+    assert(config.shouldTraceTask(attemptNumber = 0, speculative = true))
+  }
+
+  test("shouldTraceTask slowTaskMs blocks fast tasks") {
+    val config = baseConfig(slowTaskMs = 1000L)
+    assert(!config.shouldTraceTask(attemptNumber = 0, speculative = false, durationMs = 500L))
+  }
+
+  test("shouldTraceTask slowTaskMs passes slow tasks") {
+    val config = baseConfig(slowTaskMs = 1000L)
+    assert(config.shouldTraceTask(attemptNumber = 0, speculative = false, durationMs = 1500L))
+  }
+
+  test("shouldTraceTask slowTaskMs skipped when durationMs is -1 (unknown at start)") {
+    val config = baseConfig(slowTaskMs = 1000L)
+    assert(config.shouldTraceTask(attemptNumber = 0, speculative = false, durationMs = -1L))
+  }
+
+  test("shouldTraceTask all filters AND together") {
+    val config = baseConfig(
+      retryTasksOnly = true,
+      slowTaskMs     = 500L,
+      taskStageIds   = Set(7),
+    )
+    // Passes all filters: retry attempt, slow enough, correct stage
+    assert(config.shouldTraceTask(
+      attemptNumber = 1, speculative = false, stageId = 7, durationMs = 1000L))
+    // Fails retry filter
+    assert(!config.shouldTraceTask(
+      attemptNumber = 0, speculative = false, stageId = 7, durationMs = 1000L))
+    // Fails stage filter
+    assert(!config.shouldTraceTask(
+      attemptNumber = 1, speculative = false, stageId = 5, durationMs = 1000L))
+    // Fails slow task filter
+    assert(!config.shouldTraceTask(
+      attemptNumber = 1, speculative = false, stageId = 7, durationMs = 100L))
+  }
+
+  // ── FlareConfig.load() parsing tests ───────────────────────────────────────
+
+  // Use system properties to inject test values (FlareConfig reads sys.props first)
+  private val testProps = List(
+    "FLARE_ENABLED", "FLARE_TRACE_GRANULARITY", "FLARE_SAMPLING_RATIO",
+    "FLARE_MAX_SPANS_PER_TRACE", "FLARE_SLOW_TASK_MS", "FLARE_RETRY_TASKS_ONLY",
+    "FLARE_TASK_STAGES", "FLARE_TASK_STAGE_PATTERN",
+  )
+
+  override def afterEach(context: AfterEach): Unit = {
+    testProps.foreach(sys.props.remove)
+    super.afterEach(context)
+  }
+
+  test("load() parses FLARE_TASK_STAGES correctly") {
+    sys.props("FLARE_TASK_STAGES") = "7,12, 43"
+    val config = FlareConfig.load()
+    assertEquals(config.taskStageIds, Set(7, 12, 43))
+  }
+
+  test("load() throws on non-integer FLARE_TASK_STAGES") {
+    sys.props("FLARE_TASK_STAGES") = "7,abc,12"
+    interceptMessage[IllegalArgumentException]("Flare config error: FLARE_TASK_STAGES 'abc' is not an integer") {
+      FlareConfig.load()
+    }
+  }
+
+  test("load() compiles FLARE_TASK_STAGE_PATTERN as regex") {
+    sys.props("FLARE_TASK_STAGE_PATTERN") = ".*shuffle.*"
+    val config = FlareConfig.load()
+    assert(config.taskStagePattern.isDefined)
+    assert(config.taskStagePattern.get.pattern.matcher("shuffle read").matches())
+  }
+
+  test("load() throws on bad FLARE_TASK_STAGE_PATTERN regex") {
+    sys.props("FLARE_TASK_STAGE_PATTERN") = "[invalid"
+    intercept[IllegalArgumentException] {
+      FlareConfig.load()
+    }
+  }
+
+  test("load() throws on out-of-range FLARE_SAMPLING_RATIO") {
+    sys.props("FLARE_SAMPLING_RATIO") = "1.5"
+    interceptMessage[IllegalArgumentException]("Flare config error: FLARE_SAMPLING_RATIO must be 0.0-1.0, got 1.5") {
+      FlareConfig.load()
+    }
+  }
+
+  test("load() throws on non-numeric FLARE_SAMPLING_RATIO") {
+    sys.props("FLARE_SAMPLING_RATIO") = "abc"
+    interceptMessage[IllegalArgumentException]("Flare config error: FLARE_SAMPLING_RATIO 'abc' is not a number") {
+      FlareConfig.load()
+    }
+  }
+
+  test("load() defaults are sensible") {
+    val config = FlareConfig.load()
+    assert(config.enabled)
+    assertEquals(config.granularity, TraceGranularity.Stages)
+    assertEquals(config.samplingRatio, 0.1)
+    assertEquals(config.maxSpansPerTrace, 10000)
+    assertEquals(config.slowTaskMs, 0L)
+    assert(!config.retryTasksOnly)
+    assert(config.taskStageIds.isEmpty)
+    assert(config.taskStagePattern.isEmpty)
+  }
+}

--- a/src/test/scala/io/flare/spark/config/FlareConfigTest.scala
+++ b/src/test/scala/io/flare/spark/config/FlareConfigTest.scala
@@ -26,6 +26,11 @@ class FlareConfigTest extends FunSuite {
 
   // ── shouldTraceTask tests ──────────────────────────────────────────────────
 
+  test("shouldTraceTask returns false when enabled is false regardless of granularity") {
+    val config = baseConfig().copy(enabled = false)
+    assert(!config.shouldTraceTask(attemptNumber = 0, speculative = false))
+  }
+
   test("shouldTraceTask passes when no filters configured") {
     val config = baseConfig()
     assert(config.shouldTraceTask(attemptNumber = 0, speculative = false))
@@ -176,6 +181,13 @@ class FlareConfigTest extends FunSuite {
     interceptMessage[IllegalArgumentException]("Flare config error: FLARE_SAMPLING_RATIO 'abc' is not a number") {
       FlareConfig.load()
     }
+  }
+
+  test("load() FLARE_ENABLED=false disables everything") {
+    sys.props("FLARE_ENABLED") = "false"
+    val config = FlareConfig.load()
+    assert(!config.enabled)
+    assert(!config.shouldTraceTask(attemptNumber = 0, speculative = false))
   }
 
   test("load() defaults are sensible") {


### PR DESCRIPTION
Closes #3, closes #4, closes #6, closes #7, closes #8

## Summary

- **Stage-level task filtering (#3, #6):** `shouldTraceTask()` filter chain — granularity → stage IDs (`FLARE_TASK_STAGES`) → stage name pattern (`FLARE_TASK_STAGE_PATTERN`) → retry-only → slow task duration. All filters AND together. 23 new test cases in `FlareConfigTest` covering every combination and config parsing edge case.
- **Task span metrics (#8):** Shuffle read/write bytes, peak memory, input/output bytes, SQL execution ID, and duration_ms recorded from `TaskMetrics` at task end.
- **Log MDC enrichment (#4):** `trace_id` and `span_id` injected into Log4j 2 `ThreadContext` for log correlation in Grafana. Graceful no-op via `Class.forName` guard when Log4j 2 is absent.
- **Slow task drop:** Tasks faster than `FLARE_SLOW_TASK_MS` have their scope closed without `span.end()` — `BatchSpanProcessor` skips unended spans, so they never export.
- **Executor shutdown flush (#7):** Ends in-flight task spans on SIGTERM, then `forceFlush()` on `SdkTracerProvider` with `NoClassDefFoundError` guard for agent classloader isolation.

## Test plan

- [x] `sbt compile` — clean (one expected `return` warning)
- [x] `sbt test` — 31/31 pass (8 existing + 23 new)
- [x] `sbt assembly` — produces `flare-spark.jar`
- [x] CI green
- [x] Docker e2e: run SkewedJob, verify task spans have `shuffle.read_bytes`, `duration_ms`, `sql.execution_id` attributes
- [x] Docker e2e: check executor logs contain `trace_id=...` in output