### PR TITLE
Loki + Grafana traces-to-logs correlation

### DIFF
--- a/docker/alloy-config.alloy
+++ b/docker/alloy-config.alloy
@@ -1,4 +1,4 @@
-// Grafana Alloy configuration — OTLP receiver forwarding traces to Tempo
+// Grafana Alloy configuration — OTLP receiver forwarding traces to Tempo, logs to Loki
 
 otelcol.receiver.otlp "default" {
   grpc {
@@ -10,12 +10,24 @@ otelcol.receiver.otlp "default" {
 
   output {
     traces = [otelcol.exporter.otlp.tempo.input]
+    logs   = [otelcol.exporter.otlphttp.loki.input]
   }
 }
 
 otelcol.exporter.otlp "tempo" {
   client {
     endpoint = "tempo:4317"
+
+    tls {
+      insecure = true
+    }
+  }
+}
+
+// OTLP logs → Loki via OTLP HTTP (Loki 3.x supports native OTLP ingestion)
+otelcol.exporter.otlphttp "loki" {
+  client {
+    endpoint = "http://loki:3100/otlp"
 
     tls {
       insecure = true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -104,6 +104,17 @@ services:
     command: run /etc/alloy/config.alloy
     networks: [flare-net]
 
+  loki:
+    image: grafana/loki:3.4.2
+    hostname: loki
+    ports:
+      - "3100:3100"   # Loki HTTP
+    volumes:
+      - ./loki-config.yaml:/etc/loki/config.yaml:ro
+      - loki-data:/loki
+    command: -config.file=/etc/loki/config.yaml
+    networks: [flare-net]
+
   tempo:
     image: grafana/tempo:2.6.1
     hostname: tempo
@@ -128,7 +139,7 @@ services:
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - grafana-data:/var/lib/grafana
-    depends_on: [tempo]
+    depends_on: [tempo, loki]
     networks: [flare-net]
 
 networks:
@@ -138,5 +149,6 @@ networks:
 volumes:
   spark-events:
   spark-logs:
+  loki-data:
   tempo-data:
   grafana-data:

--- a/docker/grafana/provisioning/datasources/tempo.yaml
+++ b/docker/grafana/provisioning/datasources/tempo.yaml
@@ -13,7 +13,7 @@ datasources:
       tracesToLogsV2:
         datasourceUid: loki
         filterByTraceID: true
-        filterBySpanID: false
+        filterBySpanID: true
       tracesToMetrics:
         datasourceUid: ''
       nodeGraph:
@@ -28,6 +28,12 @@ datasources:
     url: http://loki:3100
     editable: false
     jsonData:
+      # Derived field creates clickable Tempo links in log lines that contain
+      # "trace_id=<hex>" in the body text. Most Spark logs won't match — the
+      # trace_id arrives as OTLP structured metadata instead. This fires only
+      # for user app code that explicitly logs the trace ID as a key=value pair.
+      # The primary logs→traces path is Grafana's built-in structured metadata
+      # detection; the primary traces→logs path is tracesToLogsV2 above.
       derivedFields:
         - datasourceUid: tempo
           matcherRegex: 'trace_id=(\w+)'

--- a/docker/grafana/provisioning/datasources/tempo.yaml
+++ b/docker/grafana/provisioning/datasources/tempo.yaml
@@ -11,10 +11,25 @@ datasources:
     jsonData:
       httpMethod: GET
       tracesToLogsV2:
-        datasourceUid: ''
+        datasourceUid: loki
+        filterByTraceID: true
+        filterBySpanID: false
       tracesToMetrics:
         datasourceUid: ''
       nodeGraph:
         enabled: true
       serviceMap:
         datasourceUid: ''
+
+  - name: Loki
+    type: loki
+    access: proxy
+    uid: loki
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: 'trace_id=(\w+)'
+          name: TraceID
+          url: '${__value.raw}'

--- a/docker/loki-config.yaml
+++ b/docker/loki-config.yaml
@@ -1,0 +1,29 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  # Accept OTLP structured metadata (trace_id, span_id) for log-to-trace correlation
+  allow_structured_metadata: true

--- a/docker/tempo-config.yaml
+++ b/docker/tempo-config.yaml
@@ -16,6 +16,24 @@ distributor:
 ingester:
   max_block_duration: 5m
 
+metrics_generator:
+  ring:
+    kvstore:
+      store: inmemory
+  processor:
+    service_graphs:
+    span_metrics:
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write: []
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors:
+        - service-graphs
+        - span-metrics
+
 storage:
   trace:
     backend: local

--- a/docker/tempo-config.yaml
+++ b/docker/tempo-config.yaml
@@ -23,6 +23,7 @@ metrics_generator:
   processor:
     service_graphs:
     span_metrics:
+    local_blocks:
   storage:
     path: /var/tempo/generator/wal
     remote_write: []
@@ -33,6 +34,7 @@ overrides:
       processors:
         - service-graphs
         - span-metrics
+        - local-blocks
 
 storage:
   trace:


### PR DESCRIPTION
Closes #5

## Summary
Adds Loki to the Docker observability stack and wires bidirectional correlation between traces (Tempo) and logs (Loki) in Grafana.

- **Loki service** (`grafana/loki:3.4.2`) with TSDB storage, OTLP native ingestion enabled via `allow_structured_metadata: true`
- **Alloy log routing** — OTEL Java agent captures Log4j 2 logs as OTLP log signals; Alloy receives them via OTLP gRPC and forwards to Loki via `otelcol.exporter.otlphttp` at `http://loki:3100/otlp`
- **Traces → Logs** — Tempo datasource's `tracesToLogsV2` points to Loki with `filterByTraceID: true`, so clicking a span in the trace view shows correlated executor/driver logs
- **Logs → Traces** — Loki datasource's `derivedFields` extracts `trace_id=(\w+)` from log lines and links back to Tempo

Depends on PR #21 for MDC enrichment (`trace_id`/`span_id` injected into Log4j 2 ThreadContext on executors).

## Test plan
- [x] `docker compose up -d` — all 8 services healthy including Loki
- [x] Loki readiness: `curl http://localhost:3100/ready` → `ready`
- [x] Run SkewedJob → both `flare-driver` and `flare-executor` logs appear in Loki (3,260 lines)
- [x] `curl localhost:3100/loki/api/v1/label/service_name/values` → `["flare-driver","flare-executor"]`
- [x] Grafana datasources provisioned: Tempo with `tracesToLogsV2→loki`, Loki with `derivedFields→tempo`
- [x] In Grafana Explore → Tempo → open trace → click span → "Logs" tab shows correlated logs
- [x] In Grafana Explore → Loki → log line with `trace_id=...` → TraceID link jumps to Tempo