### PR TITLE
ByteBuddy SparkContext auto-registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **ByteBuddy SparkContext auto-registration** — `SparkContextInstrumentationModule` hooks
+  `SparkContext.<init>` constructor exit via ByteBuddy advice to auto-register
+  `TracingSparkListener` and create the application span without `spark.plugins` config.
+  True zero-config when using the OTEL agent extension ([#14])
+- **FlareDriverState** — shared state holder with `@volatile` + `synchronized` guard for
+  dedup between SparkPlugin (Phase 1) and ByteBuddy (Phase 2) paths. First path to
+  initialize wins; the other is a no-op
+- **InstrumentationModule SPI** — `META-INF/services/` registration for auto-discovery by
+  the OTEL Java agent. Module, TypeInstrumentation, and Advice written in Java for agent
+  classloader compatibility (Scala runtime not available in extension classloader)
+- **FlareDriverState tests** — 8 tests covering initialization, dedup, shutdown idempotency,
+  re-initialization, and concurrent initialization race safety
+
+### Changed
+- **Dockerfile stable JAR names** — `COPY flare-spark.jar` and `COPY flare-examples.jar`
+  instead of `flare-spark-assembly-${FLARE_VERSION}.jar`; removed `FLARE_VERSION` build arg
+
 ## [0.2.0] - 2026-02-27
 
 ### Added
@@ -74,3 +92,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#7]: https://github.com/Neutrinic/flare/issues/7
 [#8]: https://github.com/Neutrinic/flare/issues/8
 [#9]: https://github.com/Neutrinic/flare/issues/9
+[#14]: https://github.com/Neutrinic/flare/issues/14

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val root = (project in file("."))
     buildInfoPackage := "io.flare.spark",
     buildInfoObject  := "BuildInfo",
 
-    libraryDependencies ++= otelBundled ++ otelProvided ++ byteBuddyCompileOnly ++ Seq(
+    libraryDependencies ++= otelBundled ++ otelProvided ++ otelExtensionApi ++ byteBuddyCompileOnly ++ Seq(
       "org.apache.spark" %% "spark-core" % sparkBuildVersion % "provided",
       "org.apache.spark" %% "spark-sql"  % sparkBuildVersion % "provided",
       "org.slf4j"                % "slf4j-api"  % slf4jVersion % "provided",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,6 @@ ARG SPARK_VERSION=4.0.0
 ARG SCALA_VERSION=2.13
 ARG JDK_VERSION=21
 ARG OTEL_AGENT_VERSION=2.16.0
-ARG FLARE_VERSION=0.1.0-SNAPSHOT
 
 # ── System dependencies ────────────────────────────────────────────────────────
 # No Python, no Jupyter, no Almond — Flare is JVM-only
@@ -50,8 +49,8 @@ RUN curl -L \
 # ── Flare extension JAR ────────────────────────────────────────────────────────
 # Stage the assembly JAR into docker/ before building:
 #   sbt assembly
-#   cp target/scala-2.13/flare-spark-assembly-0.1.0-SNAPSHOT.jar docker/
-COPY flare-spark-assembly-${FLARE_VERSION}.jar /opt/flare/flare-spark.jar
+#   cp target/scala-2.13/flare-spark.jar docker/
+COPY flare-spark.jar /opt/flare/flare-spark.jar
 
 # ── Spark config ───────────────────────────────────────────────────────────────
 # spark-defaults.conf pre-wires both driver and executor extraJavaOptions.
@@ -60,8 +59,8 @@ COPY spark-defaults.conf ${SPARK_HOME}/conf/spark-defaults.conf
 
 # ── Examples JAR (optional, built separately) ──────────────────────────────────
 # Stage into docker/ before building:
-#   cp examples/target/scala-2.13/flare-examples-assembly-*.jar docker/
-COPY flare-examples-assembly*.jar /opt/flare/flare-examples.jar
+#   cp examples/target/scala-2.13/flare-examples.jar docker/
+COPY flare-examples.jar /opt/flare/flare-examples.jar
 
 # ── Entrypoint ─────────────────────────────────────────────────────────────────
 COPY entrypoint.sh /entrypoint.sh

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,6 +32,12 @@ object Dependencies {
     "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure-spi" % otelVersion % "provided",
   )
 
+  // OTEL Java agent extension API — provides InstrumentationModule, TypeInstrumentation.
+  // Versioned with the agent (not SDK) and published with -alpha suffix.
+  val otelExtensionApi = Seq(
+    "io.opentelemetry.javaagent" % "opentelemetry-javaagent-extension-api" % (otelAgentVersion + "-alpha") % "provided",
+  )
+
   // Provided by the OTEL agent at runtime
   val byteBuddyCompileOnly = Seq(
     "net.bytebuddy" % "byte-buddy"       % byteBuddyVersion % "provided",

--- a/src/main/java/io/flare/spark/instrumentation/SparkContextAdvice.java
+++ b/src/main/java/io/flare/spark/instrumentation/SparkContextAdvice.java
@@ -1,0 +1,23 @@
+package io.flare.spark.instrumentation;
+
+import net.bytebuddy.asm.Advice;
+import org.apache.spark.SparkContext;
+
+/**
+ * ByteBuddy advice class for SparkContext constructor exit.
+ *
+ * <p>Written in Java because ByteBuddy copies advice bytecode literally into the
+ * target class. Scala's companion object and trait linearization produce bytecode
+ * patterns that can confuse the advice inlining mechanism. Java gives predictable,
+ * simple bytecode.
+ *
+ * <p>All real logic lives in {@link SparkContextAdviceHelper} (Scala) — this class
+ * is a thin delegation shim.
+ */
+public class SparkContextAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(@Advice.This SparkContext sparkContext) {
+        SparkContextAdviceHelper.onSparkContextInit(sparkContext);
+    }
+}

--- a/src/main/java/io/flare/spark/instrumentation/SparkContextInstrumentation.java
+++ b/src/main/java/io/flare/spark/instrumentation/SparkContextInstrumentation.java
@@ -1,0 +1,33 @@
+package io.flare.spark.instrumentation;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * TypeInstrumentation targeting {@code org.apache.spark.SparkContext}.
+ *
+ * <p>Hooks the constructor exit ({@code <init>}) so that after SparkContext is
+ * fully constructed, the ByteBuddy advice fires and registers the Flare listener
+ * + application span — no {@code spark.plugins} config needed.
+ *
+ * <p>Written in Java because the agent's extension classloader does NOT have the
+ * Scala runtime. See {@link SparkContextInstrumentationModule} for details.
+ */
+public class SparkContextInstrumentation implements TypeInstrumentation {
+
+    @Override
+    public ElementMatcher<TypeDescription> typeMatcher() {
+        return ElementMatchers.named("org.apache.spark.SparkContext");
+    }
+
+    @Override
+    public void transform(TypeTransformer transformer) {
+        transformer.applyAdviceToMethod(
+            ElementMatchers.isConstructor(),
+            SparkContextAdvice.class.getName()
+        );
+    }
+}

--- a/src/main/java/io/flare/spark/instrumentation/SparkContextInstrumentationModule.java
+++ b/src/main/java/io/flare/spark/instrumentation/SparkContextInstrumentationModule.java
@@ -45,11 +45,18 @@ public class SparkContextInstrumentationModule
      * classloader. The agent calls this method to decide which extension classes
      * to copy over.
      *
-     * <p>This includes ALL Scala classes in {@code io.flare.spark.*} since they
-     * depend on the Scala runtime which is only available on the app classloader.
+     * <p>Only production packages are listed — avoids injecting test helpers or
+     * examples that happen to share the {@code io.flare.spark} prefix.
      */
     @Override
     public boolean isHelperClass(String className) {
-        return className.startsWith("io.flare.spark.");
+        return className.startsWith("io.flare.spark.plugin.")
+            || className.startsWith("io.flare.spark.listener.")
+            || className.startsWith("io.flare.spark.instrumentation.")
+            || className.startsWith("io.flare.spark.config.")
+            || className.startsWith("io.flare.spark.propagation.")
+            || className.startsWith("io.flare.spark.attributes.")
+            || className.startsWith("io.flare.spark.SpanCompat")
+            || className.startsWith("io.flare.spark.BuildInfo");
     }
 }

--- a/src/main/java/io/flare/spark/instrumentation/SparkContextInstrumentationModule.java
+++ b/src/main/java/io/flare/spark/instrumentation/SparkContextInstrumentationModule.java
@@ -1,0 +1,55 @@
+package io.flare.spark.instrumentation;
+
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * OTEL Java agent InstrumentationModule that auto-registers Flare's driver-side
+ * listener and application span when the OTEL agent loads this extension JAR.
+ *
+ * <p>This is Phase 2: true zero-config. The user no longer needs to set
+ * {@code spark.plugins=io.flare.spark.plugin.FlareSparkPlugin} — the ByteBuddy
+ * advice hooks SparkContext construction and wires everything automatically.
+ *
+ * <p>When both SparkPlugin (Phase 1) and ByteBuddy (Phase 2) are active,
+ * FlareDriverState ensures only the first path to execute performs initialization.
+ *
+ * <p>IMPORTANT: Written in Java because the agent's extension classloader does NOT
+ * have the Scala runtime library. Only Java classes can be loaded by the agent
+ * during instrumentation setup. Scala helper classes are injected into the
+ * application classloader via {@link #isHelperClass(String)}.
+ *
+ * <p>Registered via META-INF/services/io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule
+ */
+public class SparkContextInstrumentationModule
+    extends InstrumentationModule {
+
+    public SparkContextInstrumentationModule() {
+        super("flare-spark", "flare-spark-context");
+    }
+
+    @Override
+    public List<TypeInstrumentation> typeInstrumentations() {
+        return Collections.singletonList(new SparkContextInstrumentation());
+    }
+
+    /**
+     * Tell the agent which classes from this extension must be injected into the
+     * target application classloader so that advice bytecode can reference them.
+     *
+     * <p>ByteBuddy copies advice method bytecode literally into the target class,
+     * so all types referenced by the advice must be visible from the target's
+     * classloader. The agent calls this method to decide which extension classes
+     * to copy over.
+     *
+     * <p>This includes ALL Scala classes in {@code io.flare.spark.*} since they
+     * depend on the Scala runtime which is only available on the app classloader.
+     */
+    @Override
+    public boolean isHelperClass(String className) {
+        return className.startsWith("io.flare.spark.");
+    }
+}

--- a/src/main/resources/META-INF/services/io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule
+++ b/src/main/resources/META-INF/services/io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule
@@ -1,0 +1,1 @@
+io.flare.spark.instrumentation.SparkContextInstrumentationModule

--- a/src/main/scala/io/flare/spark/instrumentation/SparkContextAdviceHelper.scala
+++ b/src/main/scala/io/flare/spark/instrumentation/SparkContextAdviceHelper.scala
@@ -62,18 +62,23 @@ object SparkContextAdviceHelper {
       val spanContext = Context.current().`with`(appSpan)
       LocalPropertyPropagator.inject(spanContext, sc)
 
-      // 3. Register TracingSparkListener
+      // 3. Create listener (but do NOT register with SparkContext yet)
       val tracingListener = new TracingSparkListener(tracer, config)
       tracingListener.setApplicationSpan(appSpan)
-      sc.addSparkListener(tracingListener)
 
-      // 4. Register in shared state (returns false if SparkPlugin raced us)
+      // 4. Atomically register in shared state — must happen BEFORE addSparkListener.
+      //    If we added the listener first and then lost the race, the duplicate listener
+      //    would remain registered on the SparkContext (no removeSparkListener API) and
+      //    produce duplicate job/stage spans for the lifetime of the application.
       if (!FlareDriverState.initialize(appSpan, tracingListener)) {
-        // Another path won the race — clean up our span and listener
+        // Another path won the race — clean up our span; listener was never registered
         appSpan.end()
         logger.info("[Flare] ByteBuddy advice: lost init race to SparkPlugin, cleaned up")
         return
       }
+
+      // 5. Won the race — safe to register the listener now
+      sc.addSparkListener(tracingListener)
 
       logger.info(
         s"[Flare] ByteBuddy advice initialized — " +

--- a/src/main/scala/io/flare/spark/instrumentation/SparkContextAdviceHelper.scala
+++ b/src/main/scala/io/flare/spark/instrumentation/SparkContextAdviceHelper.scala
@@ -1,0 +1,92 @@
+package io.flare.spark.instrumentation
+
+import io.flare.spark.BuildInfo
+import io.flare.spark.attributes.SparkAttributes._
+import io.flare.spark.config.FlareConfig
+import io.flare.spark.listener.TracingSparkListener
+import io.flare.spark.plugin.FlareDriverState
+import io.flare.spark.propagation.LocalPropertyPropagator
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.context.Context
+import org.apache.spark.SparkContext
+
+import java.util.logging.{Level, Logger}
+
+/**
+ * Scala delegation target for [[SparkContextAdvice]].
+ *
+ * Performs the same initialization as [[io.flare.spark.plugin.FlareDriverPlugin.init()]]
+ * but triggered by ByteBuddy hooking SparkContext construction instead of SparkPlugin.
+ *
+ * Uses [[FlareDriverState]] for dedup: if the SparkPlugin path already initialized,
+ * this is a no-op and vice versa.
+ *
+ * IMPORTANT: Uses java.util.logging (not SLF4J) because at advice execution time,
+ * SLF4J may not be fully initialized in the agent's extension classloader context.
+ * The java.util.logging API is always on the bootstrap classpath.
+ */
+object SparkContextAdviceHelper {
+
+  private val logger = Logger.getLogger(classOf[SparkContextAdviceHelper.type].getName)
+
+  def onSparkContextInit(sc: SparkContext): Unit = {
+    // Fast path: already initialized by SparkPlugin or a previous advice call
+    if (FlareDriverState.initialized) {
+      logger.fine("[Flare] ByteBuddy advice: already initialized, skipping")
+      return
+    }
+
+    try {
+      val config = FlareConfig.load()
+
+      if (!config.enabled) {
+        logger.info("[Flare] Disabled via FLARE_ENABLED=false")
+        return
+      }
+
+      val tracer = GlobalOpenTelemetry.getTracer("io.flare.spark", BuildInfo.version)
+
+      // 1. Create the root application span
+      val appSpan = tracer
+        .spanBuilder("spark.application")
+        .setSpanKind(SpanKind.SERVER)
+        .setAttribute(Application.Name, sc.appName)
+        .setAttribute(Application.Id, sc.applicationId)
+        .setAttribute(Application.Master, sc.master)
+        .setAttribute(Flare.Version, BuildInfo.version)
+        .setAttribute(Flare.TraceGranularity, config.granularity.toString.toLowerCase)
+        .startSpan()
+
+      // 2. Inject traceparent into SparkContext local properties
+      val spanContext = Context.current().`with`(appSpan)
+      LocalPropertyPropagator.inject(spanContext, sc)
+
+      // 3. Register TracingSparkListener
+      val tracingListener = new TracingSparkListener(tracer, config)
+      tracingListener.setApplicationSpan(appSpan)
+      sc.addSparkListener(tracingListener)
+
+      // 4. Register in shared state (returns false if SparkPlugin raced us)
+      if (!FlareDriverState.initialize(appSpan, tracingListener)) {
+        // Another path won the race — clean up our span and listener
+        appSpan.end()
+        logger.info("[Flare] ByteBuddy advice: lost init race to SparkPlugin, cleaned up")
+        return
+      }
+
+      logger.info(
+        s"[Flare] ByteBuddy advice initialized — " +
+        s"traceId=${appSpan.getSpanContext.getTraceId}, " +
+        s"granularity=${config.granularity}, " +
+        s"sampling=${config.samplingRatio}"
+      )
+
+    } catch {
+      case e: IllegalArgumentException =>
+        logger.log(Level.SEVERE, s"[Flare] Configuration error — advice disabled: ${e.getMessage}", e)
+      case e: Exception =>
+        logger.log(Level.SEVERE, s"[Flare] ByteBuddy advice init failed: ${e.getMessage}", e)
+    }
+  }
+}

--- a/src/main/scala/io/flare/spark/plugin/FlareDriverPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareDriverPlugin.scala
@@ -40,6 +40,12 @@ class FlareDriverPlugin extends DriverPlugin {
   private var listener: Option[TracingSparkListener] = None
 
   override def init(sc: SparkContext, pluginContext: PluginContext): ju.Map[String, String] = {
+    // Dedup guard: if ByteBuddy advice already initialized (Phase 2), skip plugin init.
+    if (FlareDriverState.initialized) {
+      logger.info("[Flare] Already initialized by ByteBuddy advice, skipping plugin init")
+      return ju.Collections.emptyMap()
+    }
+
     val config = try FlareConfig.load() catch {
       case e: IllegalArgumentException =>
         logger.error(s"[Flare] Configuration error — plugin disabled: ${e.getMessage}")
@@ -79,6 +85,9 @@ class FlareDriverPlugin extends DriverPlugin {
     sc.addSparkListener(tracingListener)
     listener = Some(tracingListener)
 
+    // 4. Register in shared state so ByteBuddy advice (if loaded later) skips init
+    FlareDriverState.initialize(appSpan, tracingListener)
+
     logger.info(s"[Flare] Driver plugin initialized — " +
       s"traceId=${appSpan.getSpanContext.getTraceId}, " +
       s"granularity=${config.granularity}, " +
@@ -88,15 +97,14 @@ class FlareDriverPlugin extends DriverPlugin {
   }
 
   override def shutdown(): Unit = {
-    // Delegate to the listener which ends all open spans (stages, jobs, app).
-    // The listener's shutdown() calls span.end() on the application span.
-    // Span.end() is idempotent, but setStatus after end() is a no-op — so we
-    // must NOT unconditionally set OK here, as that would silently mask an
-    // ERROR status set by the listener's onApplicationEnd or shutdown path.
-    listener.foreach(_.shutdown())
+    // Delegate to FlareDriverState which coordinates with both SparkPlugin and
+    // ByteBuddy paths. FlareDriverState.shutdown() calls listener.shutdown()
+    // which ends all open spans (stages, jobs, app).
+    FlareDriverState.shutdown()
 
     // Only end the application span directly if the listener was never registered
-    // (e.g., init failed partway through before addSparkListener).
+    // (e.g., init failed partway through before addSparkListener, or FlareDriverState
+    // was never initialized because config was invalid/disabled).
     if (listener.isEmpty) {
       applicationSpan.foreach { span =>
         span.setStatus(StatusCode.OK)

--- a/src/main/scala/io/flare/spark/plugin/FlareDriverState.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareDriverState.scala
@@ -1,0 +1,69 @@
+package io.flare.spark.plugin
+
+import io.flare.spark.listener.TracingSparkListener
+import io.opentelemetry.api.trace.Span
+
+import java.util.logging.Logger
+
+/**
+ * Shared driver-side state that prevents double-initialization when both the
+ * SparkPlugin path (Phase 1) and ByteBuddy advice path (Phase 2) are active.
+ *
+ * First path to call [[initialize]] wins; the second is a no-op.
+ *
+ * Uses `@volatile` + `synchronized` for correctness:
+ * - `@volatile` on [[initialized]] allows fast non-locking reads in the common
+ *   case (already initialized).
+ * - `synchronized` in [[initialize]] and [[shutdown]] ensures only one thread
+ *   can perform the transition.
+ *
+ * IMPORTANT: Uses java.util.logging (not SLF4J) because this class is loaded
+ * by the OTEL agent's extension classloader where SLF4J is shaded and not
+ * visible to extensions.
+ */
+object FlareDriverState {
+
+  private val logger = Logger.getLogger(classOf[FlareDriverState.type].getName)
+
+  @volatile var initialized: Boolean = false
+  @volatile private[plugin] var applicationSpan: Option[Span] = None
+  @volatile private var listener: Option[TracingSparkListener] = None
+
+  /**
+   * Attempt to initialize. Returns true if this call performed the initialization,
+   * false if it was already done by another path.
+   */
+  def initialize(span: Span, tracingListener: TracingSparkListener): Boolean = synchronized {
+    if (initialized) {
+      logger.info("[Flare] Already initialized, skipping duplicate init")
+      false
+    } else {
+      applicationSpan = Some(span)
+      listener = Some(tracingListener)
+      initialized = true
+      logger.info("[Flare] Driver state initialized")
+      true
+    }
+  }
+
+  /**
+   * Shutdown: delegate to the listener (which ends all open spans including
+   * the application span). Idempotent — safe to call from both plugin shutdown
+   * and a JVM shutdown hook.
+   */
+  def shutdown(): Unit = synchronized {
+    if (!initialized) return
+    listener.foreach(_.shutdown())
+    applicationSpan = None
+    listener = None
+    initialized = false
+    logger.info("[Flare] Driver state shut down")
+  }
+
+  /** Visible for testing — reset all state. */
+  private[plugin] def reset(): Unit = synchronized {
+    applicationSpan = None
+    listener = None
+    initialized = false
+  }
+}

--- a/src/main/scala/io/flare/spark/plugin/FlareDriverState.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareDriverState.scala
@@ -25,22 +25,25 @@ object FlareDriverState {
 
   private val logger = Logger.getLogger(classOf[FlareDriverState.type].getName)
 
-  @volatile var initialized: Boolean = false
+  @volatile private var _initialized: Boolean = false
   @volatile private[plugin] var applicationSpan: Option[Span] = None
   @volatile private var listener: Option[TracingSparkListener] = None
+
+  /** Read-only access to initialization state. */
+  def initialized: Boolean = _initialized
 
   /**
    * Attempt to initialize. Returns true if this call performed the initialization,
    * false if it was already done by another path.
    */
   def initialize(span: Span, tracingListener: TracingSparkListener): Boolean = synchronized {
-    if (initialized) {
+    if (_initialized) {
       logger.info("[Flare] Already initialized, skipping duplicate init")
       false
     } else {
       applicationSpan = Some(span)
       listener = Some(tracingListener)
-      initialized = true
+      _initialized = true
       logger.info("[Flare] Driver state initialized")
       true
     }
@@ -52,11 +55,11 @@ object FlareDriverState {
    * and a JVM shutdown hook.
    */
   def shutdown(): Unit = synchronized {
-    if (!initialized) return
+    if (!_initialized) return
     listener.foreach(_.shutdown())
     applicationSpan = None
     listener = None
-    initialized = false
+    _initialized = false
     logger.info("[Flare] Driver state shut down")
   }
 
@@ -64,6 +67,6 @@ object FlareDriverState {
   private[plugin] def reset(): Unit = synchronized {
     applicationSpan = None
     listener = None
-    initialized = false
+    _initialized = false
   }
 }

--- a/src/test/scala/io/flare/spark/plugin/FlareDriverStateTest.scala
+++ b/src/test/scala/io/flare/spark/plugin/FlareDriverStateTest.scala
@@ -1,0 +1,146 @@
+package io.flare.spark.plugin
+
+import io.flare.spark.config.{FlareConfig, TraceGranularity}
+import io.flare.spark.listener.TracingSparkListener
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
+import munit.FunSuite
+
+class FlareDriverStateTest extends FunSuite {
+
+  private val exporter = InMemorySpanExporter.create()
+
+  private val tracerProvider: SdkTracerProvider = SdkTracerProvider.builder()
+    .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+    .build()
+
+  private val sdk: OpenTelemetrySdk = OpenTelemetrySdk.builder()
+    .setTracerProvider(tracerProvider)
+    .build()
+
+  private val tracer: Tracer = sdk.getTracer("test")
+
+  private val testConfig: FlareConfig = FlareConfig(
+    enabled          = true,
+    granularity      = TraceGranularity.Stages,
+    samplingRatio    = 1.0,
+    maxSpansPerTrace = 10000,
+    slowTaskMs       = 0L,
+    retryTasksOnly   = false,
+    taskStageIds     = Set.empty,
+    taskStagePattern = None,
+  )
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    FlareDriverState.reset()
+    exporter.reset()
+    super.beforeEach(context)
+  }
+
+  // ── Basic lifecycle ─────────────────────────────────────────────────────────
+
+  test("starts uninitialized") {
+    assert(!FlareDriverState.initialized)
+  }
+
+  test("initialize sets initialized to true and returns true") {
+    val span = tracer.spanBuilder("test-app").startSpan()
+    val listener = new TracingSparkListener(tracer, testConfig)
+    assert(FlareDriverState.initialize(span, listener))
+    assert(FlareDriverState.initialized)
+    span.end()
+  }
+
+  test("second initialize returns false (dedup)") {
+    val span1 = tracer.spanBuilder("app1").startSpan()
+    val listener1 = new TracingSparkListener(tracer, testConfig)
+    assert(FlareDriverState.initialize(span1, listener1))
+
+    val span2 = tracer.spanBuilder("app2").startSpan()
+    val listener2 = new TracingSparkListener(tracer, testConfig)
+    assert(!FlareDriverState.initialize(span2, listener2))
+
+    // First span is still the one in state
+    assert(FlareDriverState.applicationSpan.contains(span1))
+    span1.end()
+    span2.end()
+  }
+
+  test("shutdown resets state") {
+    val span = tracer.spanBuilder("test-app").startSpan()
+    val listener = new TracingSparkListener(tracer, testConfig)
+    FlareDriverState.initialize(span, listener)
+    assert(FlareDriverState.initialized)
+
+    FlareDriverState.shutdown()
+    assert(!FlareDriverState.initialized)
+  }
+
+  test("shutdown is idempotent") {
+    val span = tracer.spanBuilder("test-app").startSpan()
+    val listener = new TracingSparkListener(tracer, testConfig)
+    FlareDriverState.initialize(span, listener)
+
+    FlareDriverState.shutdown()
+    assert(!FlareDriverState.initialized)
+    // Second shutdown is a no-op — should not throw
+    FlareDriverState.shutdown()
+    assert(!FlareDriverState.initialized)
+  }
+
+  test("can re-initialize after shutdown") {
+    val span1 = tracer.spanBuilder("app1").startSpan()
+    val listener1 = new TracingSparkListener(tracer, testConfig)
+    FlareDriverState.initialize(span1, listener1)
+    FlareDriverState.shutdown()
+
+    val span2 = tracer.spanBuilder("app2").startSpan()
+    val listener2 = new TracingSparkListener(tracer, testConfig)
+    assert(FlareDriverState.initialize(span2, listener2))
+    assert(FlareDriverState.initialized)
+    assert(FlareDriverState.applicationSpan.contains(span2))
+    span2.end()
+  }
+
+  test("reset clears all state without calling listener shutdown") {
+    val span = tracer.spanBuilder("test-app").startSpan()
+    val listener = new TracingSparkListener(tracer, testConfig)
+    FlareDriverState.initialize(span, listener)
+
+    FlareDriverState.reset()
+    assert(!FlareDriverState.initialized)
+    assert(FlareDriverState.applicationSpan.isEmpty)
+    span.end()
+  }
+
+  // ── Thread safety ─────────────────────────────────────────────────────────
+
+  test("concurrent initialize calls — exactly one wins") {
+    import java.util.concurrent.{CountDownLatch, CyclicBarrier}
+    import java.util.concurrent.atomic.AtomicInteger
+
+    val barrier = new CyclicBarrier(10)
+    val wins = new AtomicInteger(0)
+    val latch = new CountDownLatch(10)
+
+    (1 to 10).foreach { i =>
+      new Thread(() => {
+        val span = tracer.spanBuilder(s"app-$i").startSpan()
+        val listener = new TracingSparkListener(tracer, testConfig)
+        barrier.await() // all threads start together
+        if (FlareDriverState.initialize(span, listener)) {
+          wins.incrementAndGet()
+        }
+        span.end()
+        latch.countDown()
+      }).start()
+    }
+
+    latch.await()
+    assertEquals(wins.get(), 1, "Exactly one thread should win the init race")
+    assert(FlareDriverState.initialized)
+  }
+}


### PR DESCRIPTION
Closes #14

## Summary
- **Phase 2 zero-config**: `SparkContextInstrumentationModule` hooks `SparkContext.<init>` constructor exit via ByteBuddy advice to auto-register `TracingSparkListener` and create the application span — no `spark.plugins` config needed
- **FlareDriverState**: shared `@volatile` + `synchronized` state holder prevents double-initialization when both SparkPlugin (Phase 1) and ByteBuddy (Phase 2) paths are active. First path to execute wins
- **Java for agent classloader**: `InstrumentationModule`, `TypeInstrumentation`, and `@Advice` class written in Java because the OTEL agent's extension classloader does not have the Scala runtime. Scala `SparkContextAdviceHelper` is injected into the app classloader via `isHelperClass`
- **SPI registration**: `META-INF/services/InstrumentationModule` for auto-discovery by the OTEL Java agent
- **Dockerfile**: updated to use stable JAR names (`flare-spark.jar` / `flare-examples.jar`), removed `FLARE_VERSION` build arg
- 8 new `FlareDriverState` tests (49 total, all passing)

## Deployment modes
| Mode | How it works |
|------|-------------|
| Agent extension only (Phase 2) | ByteBuddy fires on SparkContext init, no `spark.plugins` needed |
| SparkPlugin only (Phase 1) | `FlareDriverPlugin.init()` runs, registers in `FlareDriverState` |
| Both configured | First path wins, second is a no-op via `FlareDriverState` dedup |

## Test plan
- [x] `sbt test` — 49 tests pass (8 new FlareDriverState tests)
- [x] `sbt assembly` — SPI files bundled in JAR
- [x] Docker e2e WITH `spark.plugins` — Phase 1 path works, dedup prevents double spans
- [x] Docker e2e WITHOUT `spark.plugins` — ByteBuddy advice fires, driver spans in Tempo
- [x] No duplicate spans in either mode