### PR TITLE
ByteBuddy TaskRunner context restoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **ByteBuddy TaskRunner context restoration** — `TaskRunnerInstrumentationModule` hooks
+  `Executor$TaskRunner.run()` to extract `traceparent` from `TaskDescription.properties`
+  and make the parent OTEL context current for the entire task execution. Downstream
+  OTEL-instrumented libraries (JDBC, HTTP, gRPC) inside tasks now inherit the correct
+  parent context. Context-only — no span creation, `FlareExecutorPlugin` manages span
+  lifecycle as before ([#15])
+- **`LocalPropertyPropagator.extractFromProperties`** — overloaded extraction method taking
+  `java.util.Properties` directly for use in TaskRunner advice where `TaskContext` is null
 - **ByteBuddy SparkContext auto-registration** — `SparkContextInstrumentationModule` hooks
   `SparkContext.<init>` constructor exit via ByteBuddy advice to auto-register
   `TracingSparkListener` and create the application span without `spark.plugins` config.
@@ -93,3 +101,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#8]: https://github.com/Neutrinic/flare/issues/8
 [#9]: https://github.com/Neutrinic/flare/issues/9
 [#14]: https://github.com/Neutrinic/flare/issues/14
+[#15]: https://github.com/Neutrinic/flare/issues/15

--- a/src/main/java/io/flare/spark/instrumentation/TaskRunnerAdvice.java
+++ b/src/main/java/io/flare/spark/instrumentation/TaskRunnerAdvice.java
@@ -1,0 +1,33 @@
+package io.flare.spark.instrumentation;
+
+import io.opentelemetry.context.Scope;
+import net.bytebuddy.asm.Advice;
+
+/**
+ * ByteBuddy advice for {@code Executor$TaskRunner.run()}.
+ *
+ * <p>On method enter: extracts {@code traceparent} from the task's serialized properties
+ * (via {@code taskDescription} field) and makes the parent OTEL context current.
+ *
+ * <p>On method exit: closes the scope, restoring the previous context.
+ *
+ * <p>This does NOT create spans — it only restores context. Span lifecycle is managed by
+ * {@code FlareExecutorPlugin}, which fires inside {@code run()} after {@code TaskContext}
+ * is set up.
+ *
+ * <p>Written in Java for reliable bytecode inlining. All real logic lives in
+ * {@link TaskRunnerAdviceHelper}.
+ */
+public class TaskRunnerAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static Scope onEnter(
+            @Advice.FieldValue("taskDescription") Object taskDescription) {
+        return TaskRunnerAdviceHelper.onEnter(taskDescription);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    public static void onExit(@Advice.Enter Scope scope) {
+        TaskRunnerAdviceHelper.onExit(scope);
+    }
+}

--- a/src/main/java/io/flare/spark/instrumentation/TaskRunnerInstrumentation.java
+++ b/src/main/java/io/flare/spark/instrumentation/TaskRunnerInstrumentation.java
@@ -1,0 +1,36 @@
+package io.flare.spark.instrumentation;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * TypeInstrumentation targeting {@code org.apache.spark.executor.Executor$TaskRunner}.
+ *
+ * <p>Hooks the {@code run()} method so that the OTEL parent context (from the task's
+ * {@code traceparent} local property) is active for the entire task execution, including
+ * plugin callbacks and the task lambda.
+ *
+ * <p>{@code TaskRunner} is {@code private[spark]} and an inner class of {@code Executor}.
+ * JVM bytecode name is {@code Executor$TaskRunner}. This is a private API — muzzle checks
+ * should validate it against each supported Spark version.
+ *
+ * <p>Written in Java because the agent's extension classloader does not have the Scala runtime.
+ */
+public class TaskRunnerInstrumentation implements TypeInstrumentation {
+
+    @Override
+    public ElementMatcher<TypeDescription> typeMatcher() {
+        return ElementMatchers.named("org.apache.spark.executor.Executor$TaskRunner");
+    }
+
+    @Override
+    public void transform(TypeTransformer transformer) {
+        transformer.applyAdviceToMethod(
+            ElementMatchers.named("run").and(ElementMatchers.takesNoArguments()),
+            TaskRunnerAdvice.class.getName()
+        );
+    }
+}

--- a/src/main/java/io/flare/spark/instrumentation/TaskRunnerInstrumentationModule.java
+++ b/src/main/java/io/flare/spark/instrumentation/TaskRunnerInstrumentationModule.java
@@ -1,0 +1,54 @@
+package io.flare.spark.instrumentation;
+
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * OTEL Java agent InstrumentationModule targeting Spark's {@code TaskRunner.run()} on the
+ * executor JVM.
+ *
+ * <p>This makes the OTEL parent context (extracted from the task's {@code traceparent} local
+ * property) active for the entire duration of {@code TaskRunner.run()}, including Spark's
+ * plugin callbacks and the task lambda. Any downstream OTEL-instrumented library (JDBC, HTTP,
+ * gRPC) running inside the task will inherit the correct parent context.
+ *
+ * <p>This does NOT create spans — span lifecycle is managed by {@code FlareExecutorPlugin}.
+ * The advice only restores context, keeping the change minimal and avoiding duplicate spans.
+ *
+ * <p>Written in Java because the agent's extension classloader does not have the Scala runtime.
+ *
+ * <p>Registered via META-INF/services/io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule
+ */
+public class TaskRunnerInstrumentationModule
+    extends InstrumentationModule {
+
+    public TaskRunnerInstrumentationModule() {
+        super("flare-spark", "flare-spark-taskrunner");
+    }
+
+    @Override
+    public List<TypeInstrumentation> typeInstrumentations() {
+        return Collections.singletonList(new TaskRunnerInstrumentation());
+    }
+
+    /**
+     * Inject all Flare extension classes into the target application classloader.
+     *
+     * <p>Only production packages are listed — avoids injecting test helpers or
+     * examples that happen to share the {@code io.flare.spark} prefix.
+     */
+    @Override
+    public boolean isHelperClass(String className) {
+        return className.startsWith("io.flare.spark.plugin.")
+            || className.startsWith("io.flare.spark.listener.")
+            || className.startsWith("io.flare.spark.instrumentation.")
+            || className.startsWith("io.flare.spark.config.")
+            || className.startsWith("io.flare.spark.propagation.")
+            || className.startsWith("io.flare.spark.attributes.")
+            || className.startsWith("io.flare.spark.SpanCompat")
+            || className.startsWith("io.flare.spark.BuildInfo");
+    }
+}

--- a/src/main/resources/META-INF/services/io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule
+++ b/src/main/resources/META-INF/services/io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule
@@ -1,1 +1,2 @@
 io.flare.spark.instrumentation.SparkContextInstrumentationModule
+io.flare.spark.instrumentation.TaskRunnerInstrumentationModule

--- a/src/main/scala/io/flare/spark/instrumentation/TaskRunnerAdviceHelper.scala
+++ b/src/main/scala/io/flare/spark/instrumentation/TaskRunnerAdviceHelper.scala
@@ -1,0 +1,94 @@
+package io.flare.spark.instrumentation
+
+import io.flare.spark.propagation.LocalPropertyPropagator
+import io.opentelemetry.context.{Context, Scope}
+
+import java.util.logging.{Level, Logger}
+
+/**
+ * Scala delegation target for [[TaskRunnerAdvice]].
+ *
+ * Extracts the W3C `traceparent` from the task's serialized properties and makes
+ * the parent OTEL context current for the entire duration of `TaskRunner.run()`.
+ *
+ * This does NOT create spans — it only restores context. Span lifecycle is managed
+ * by `FlareExecutorPlugin`, which fires inside `run()` after `TaskContext` is set.
+ *
+ * At `@Advice.OnMethodEnter` time, `TaskContext.get()` is null because Spark sets
+ * it later inside `run()`. Instead, the advice reads the `taskDescription` field
+ * directly (via `@Advice.FieldValue`) and accesses `TaskDescription.properties`
+ * via reflection since `TaskDescription` is `private[spark]`.
+ *
+ * IMPORTANT: Uses `java.util.logging` (not SLF4J) because at advice execution time,
+ * SLF4J may not be fully initialized in the agent's extension classloader context.
+ */
+object TaskRunnerAdviceHelper {
+
+  private val logger = Logger.getLogger(classOf[TaskRunnerAdviceHelper.type].getName)
+
+  // Cached reflection — Method objects are thread-safe for invoke()
+  @volatile private var propertiesMethod: java.lang.reflect.Method = _
+
+  /**
+   * Called from `@Advice.OnMethodEnter`.
+   *
+   * @param taskDescription the `TaskDescription` instance from `TaskRunner.taskDescription`
+   *                        field, injected by ByteBuddy's `@Advice.FieldValue`
+   * @return an OTEL `Scope` that must be closed in `onExit`, or null if no context
+   *         was extracted (no traceparent, or root context only)
+   */
+  def onEnter(taskDescription: Any): Scope = {
+    if (taskDescription == null) return null
+    try {
+      val props = getProperties(taskDescription)
+      if (props == null) return null
+
+      val parentContext = LocalPropertyPropagator.extractFromProperties(props)
+      if (parentContext == Context.root()) {
+        null
+      } else {
+        parentContext.makeCurrent()
+      }
+    } catch {
+      case e: Exception =>
+        logger.log(Level.FINE, "[Flare] TaskRunner advice enter failed", e)
+        null
+    }
+  }
+
+  /**
+   * Called from `@Advice.OnMethodExit`.
+   *
+   * @param scope the `Scope` returned from `onEnter`, may be null
+   */
+  def onExit(scope: Scope): Unit = {
+    if (scope != null) {
+      try {
+        scope.close()
+      } catch {
+        case e: Exception =>
+          logger.log(Level.FINE, "[Flare] TaskRunner advice exit failed", e)
+      }
+    }
+  }
+
+  /**
+   * Access `TaskDescription.properties` via reflection.
+   *
+   * `TaskDescription` is `private[spark]` so we cannot reference it by type
+   * from extension code. The `properties` method is a public accessor on the
+   * case class, returning `java.util.Properties`.
+   *
+   * The Method reference is cached after first successful lookup. `@volatile`
+   * + double-check is sufficient — worst case is two threads both do the
+   * reflective lookup, which is harmless.
+   */
+  private def getProperties(taskDescription: Any): java.util.Properties = {
+    var m = propertiesMethod
+    if (m == null) {
+      m = taskDescription.getClass.getMethod("properties")
+      propertiesMethod = m
+    }
+    m.invoke(taskDescription).asInstanceOf[java.util.Properties]
+  }
+}

--- a/src/main/scala/io/flare/spark/instrumentation/TaskRunnerAdviceHelper.scala
+++ b/src/main/scala/io/flare/spark/instrumentation/TaskRunnerAdviceHelper.scala
@@ -79,9 +79,11 @@ object TaskRunnerAdviceHelper {
    * from extension code. The `properties` method is a public accessor on the
    * case class, returning `java.util.Properties`.
    *
-   * The Method reference is cached after first successful lookup. `@volatile`
-   * + double-check is sufficient — worst case is two threads both do the
-   * reflective lookup, which is harmless.
+   * The Method reference is cached after first successful lookup. This is a
+   * benign race, not proper double-checked locking — two threads can both see
+   * null and both do the reflective lookup. This is harmless: both resolve to
+   * the same Method object, and the write to `@volatile propertiesMethod` is
+   * atomic. Not worth synchronizing for a one-time-per-JVM lookup.
    */
   private def getProperties(taskDescription: Any): java.util.Properties = {
     var m = propertiesMethod

--- a/src/main/scala/io/flare/spark/propagation/LocalPropertyPropagator.scala
+++ b/src/main/scala/io/flare/spark/propagation/LocalPropertyPropagator.scala
@@ -89,6 +89,13 @@ object LocalPropertyPropagator {
     }
 
   // ── TextMapGetter for java.util.Properties ────────────────────────────────
+  //
+  // keys() intentionally returns only W3C header names. The W3C propagator
+  // (default OTEL_PROPAGATORS) calls get() with "traceparent"/"tracestate"
+  // directly. If a non-W3C propagator is configured (B3, Jaeger), it will
+  // call get() with its own key names — Properties.getProperty will return
+  // null for missing keys, which is the correct "not present" signal.
+  // The keys() iterable is advisory and most propagators don't iterate it.
 
   private[propagation] val PropertiesGetter: TextMapGetter[ju.Properties] =
     new TextMapGetter[ju.Properties] {

--- a/src/main/scala/io/flare/spark/propagation/LocalPropertyPropagator.scala
+++ b/src/main/scala/io/flare/spark/propagation/LocalPropertyPropagator.scala
@@ -55,6 +55,20 @@ object LocalPropertyPropagator {
     parentContext
   }
 
+  /**
+   * Extract OTEL parent context from a raw `java.util.Properties` instance.
+   *
+   * Used by `TaskRunnerAdviceHelper` where `TaskContext` is not yet available —
+   * the ByteBuddy advice fires at the top of `TaskRunner.run()` before Spark sets
+   * `TaskContext.get()`. The traceparent is read directly from
+   * `TaskDescription.properties` via `@Advice.FieldValue`.
+   */
+  def extractFromProperties(props: ju.Properties): OtelContext = {
+    if (props == null) return OtelContext.root()
+    val propagator = GlobalOpenTelemetry.getPropagators.getTextMapPropagator
+    propagator.extract(OtelContext.root(), props, PropertiesGetter)
+  }
+
   // ── TextMapSetter for SparkContext ─────────────────────────────────────────
 
   private val SparkContextSetter: TextMapSetter[SparkContext] =
@@ -72,5 +86,17 @@ object LocalPropertyPropagator {
       override def get(carrier: TaskContext, key: String): String =
         if (carrier == null) null
         else carrier.getLocalProperty(key)
+    }
+
+  // ── TextMapGetter for java.util.Properties ────────────────────────────────
+
+  private[propagation] val PropertiesGetter: TextMapGetter[ju.Properties] =
+    new TextMapGetter[ju.Properties] {
+      override def keys(carrier: ju.Properties): java.lang.Iterable[String] =
+        ju.Arrays.asList(TraceparentKey, TracestateKey)
+
+      override def get(carrier: ju.Properties, key: String): String =
+        if (carrier == null) null
+        else carrier.getProperty(key)
     }
 }

--- a/src/test/scala/io/flare/spark/instrumentation/TaskRunnerAdviceHelperTest.scala
+++ b/src/test/scala/io/flare/spark/instrumentation/TaskRunnerAdviceHelperTest.scala
@@ -1,0 +1,216 @@
+package io.flare.spark.instrumentation
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.{Span, SpanKind, Tracer}
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
+import munit.FunSuite
+
+import java.{util => ju}
+
+/**
+ * Unit tests for [[TaskRunnerAdviceHelper]].
+ *
+ * Tests the extraction logic and context scoping without requiring a real
+ * Spark TaskRunner — uses a mock object with a `properties()` method to
+ * simulate `TaskDescription`.
+ */
+class TaskRunnerAdviceHelperTest extends FunSuite {
+
+  private val exporter = InMemorySpanExporter.create()
+
+  private val tracerProvider: SdkTracerProvider = SdkTracerProvider.builder()
+    .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+    .build()
+
+  private val sdk: OpenTelemetrySdk = OpenTelemetrySdk.builder()
+    .setTracerProvider(tracerProvider)
+    .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+    .buildAndRegisterGlobal()
+
+  private val tracer: Tracer = sdk.getTracer("test")
+
+  override def afterAll(): Unit = {
+    GlobalOpenTelemetry.resetForTest()
+    tracerProvider.shutdown()
+    super.afterAll()
+  }
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    exporter.reset()
+    super.beforeEach(context)
+  }
+
+  // ── Helper: mock TaskDescription with properties() method ─────────────
+
+  /** Mimics TaskDescription's `properties` accessor via reflection. */
+  class MockTaskDescription(val props: ju.Properties) {
+    def properties(): ju.Properties = props
+  }
+
+  private def makeTraceparent(span: Span): String = {
+    val sc = span.getSpanContext
+    val flags = if (sc.isSampled) "01" else "00"
+    s"00-${sc.getTraceId}-${sc.getSpanId}-$flags"
+  }
+
+  // ── Tests ─────────────────────────────────────────────────────────────
+
+  test("onEnter returns null for null taskDescription") {
+    val scope = TaskRunnerAdviceHelper.onEnter(null)
+    assert(scope == null)
+  }
+
+  test("onEnter returns null when properties has no traceparent") {
+    val props = new ju.Properties()
+    val mock = new MockTaskDescription(props)
+    val scope = TaskRunnerAdviceHelper.onEnter(mock)
+    assert(scope == null)
+  }
+
+  test("onEnter returns Scope and makes parent context current") {
+    val parentSpan = tracer.spanBuilder("parent")
+      .setSpanKind(SpanKind.SERVER)
+      .startSpan()
+
+    try {
+      val traceparent = makeTraceparent(parentSpan)
+      val props = new ju.Properties()
+      props.setProperty("traceparent", traceparent)
+
+      val mock = new MockTaskDescription(props)
+      val scope = TaskRunnerAdviceHelper.onEnter(mock)
+
+      assert(scope != null, "Scope should be non-null when traceparent is present")
+
+      // The current context should contain the parent span's trace context
+      val currentSpan = Span.fromContext(Context.current())
+      assertEquals(
+        currentSpan.getSpanContext.getTraceId,
+        parentSpan.getSpanContext.getTraceId
+      )
+      assertEquals(
+        currentSpan.getSpanContext.getSpanId,
+        parentSpan.getSpanContext.getSpanId
+      )
+
+      scope.close()
+    } finally {
+      parentSpan.end()
+    }
+  }
+
+  test("onExit closes scope and restores previous context") {
+    val parentSpan = tracer.spanBuilder("parent").startSpan()
+
+    try {
+      val traceparent = makeTraceparent(parentSpan)
+      val props = new ju.Properties()
+      props.setProperty("traceparent", traceparent)
+
+      // Record the context before entering
+      val contextBefore = Context.current()
+
+      val mock = new MockTaskDescription(props)
+      val scope = TaskRunnerAdviceHelper.onEnter(mock)
+      assert(scope != null)
+
+      // Context changed
+      assert(Context.current() != contextBefore)
+
+      // Exit restores it
+      TaskRunnerAdviceHelper.onExit(scope)
+      assertEquals(Context.current(), contextBefore)
+    } finally {
+      parentSpan.end()
+    }
+  }
+
+  test("onExit is safe with null scope") {
+    // Should not throw
+    TaskRunnerAdviceHelper.onExit(null)
+  }
+
+  test("onEnter with tracestate propagates both headers") {
+    val parentSpan = tracer.spanBuilder("parent").startSpan()
+
+    try {
+      val traceparent = makeTraceparent(parentSpan)
+      val props = new ju.Properties()
+      props.setProperty("traceparent", traceparent)
+      props.setProperty("tracestate", "vendor=value")
+
+      val mock = new MockTaskDescription(props)
+      val scope = TaskRunnerAdviceHelper.onEnter(mock)
+      assert(scope != null)
+      scope.close()
+    } finally {
+      parentSpan.end()
+    }
+  }
+
+  test("onEnter with invalid traceparent returns null") {
+    val props = new ju.Properties()
+    props.setProperty("traceparent", "not-a-valid-traceparent")
+
+    val mock = new MockTaskDescription(props)
+    val scope = TaskRunnerAdviceHelper.onEnter(mock)
+    // Invalid traceparent → extraction returns root context → null scope
+    assert(scope == null)
+  }
+
+  test("onEnter with object lacking properties method returns null") {
+    // Pass an object that doesn't have a properties() method
+    val scope = TaskRunnerAdviceHelper.onEnter("not-a-task-description")
+    assert(scope == null, "Should gracefully handle missing properties method")
+  }
+
+  test("child span created inside scope has correct parent") {
+    val parentSpan = tracer.spanBuilder("parent")
+      .setSpanKind(SpanKind.SERVER)
+      .startSpan()
+
+    try {
+      val traceparent = makeTraceparent(parentSpan)
+      val props = new ju.Properties()
+      props.setProperty("traceparent", traceparent)
+
+      val mock = new MockTaskDescription(props)
+      val scope = TaskRunnerAdviceHelper.onEnter(mock)
+      assert(scope != null)
+
+      // Create a child span — simulates what ExecutorPlugin or JDBC instrumentation does
+      val childSpan = tracer.spanBuilder("spark.task.executor")
+        .setSpanKind(SpanKind.INTERNAL)
+        .startSpan()
+      childSpan.end()
+
+      scope.close()
+
+      // Verify the child span's parent is the remote parent
+      val spans = exporter.getFinishedSpanItems
+      val childExport = spans.stream()
+        .filter(s => s.getName == "spark.task.executor")
+        .findFirst()
+        .orElseThrow()
+
+      assertEquals(
+        childExport.getParentSpanId,
+        parentSpan.getSpanContext.getSpanId,
+        "Child span should be parented under the extracted remote context"
+      )
+      assertEquals(
+        childExport.getTraceId,
+        parentSpan.getSpanContext.getTraceId,
+        "Child span should share the same traceId"
+      )
+    } finally {
+      parentSpan.end()
+    }
+  }
+}


### PR DESCRIPTION
Closes #15

## Summary
- Hook `Executor$TaskRunner.run()` via ByteBuddy to extract `traceparent` from `TaskDescription.properties` and make the parent OTEL context current for the entire task execution
- Downstream OTEL-instrumented libraries (JDBC, HTTP, gRPC) inside tasks now inherit the correct parent context
- Context-only — no span creation; `FlareExecutorPlugin` continues managing span lifecycle, metrics, filters, and MDC enrichment
- `LocalPropertyPropagator.extractFromProperties(Properties)` overload for use where `TaskContext` is null

## New Files
| File | Language | Purpose |
|------|----------|---------|
| `TaskRunnerInstrumentationModule.java` | Java | `InstrumentationModule` SPI — agent classloader |
| `TaskRunnerInstrumentation.java` | Java | `TypeInstrumentation` targeting `Executor$TaskRunner` |
| `TaskRunnerAdvice.java` | Java | `@Advice` enter/exit — thin delegation to Scala helper |
| `TaskRunnerAdviceHelper.scala` | Scala | Extract traceparent from task properties, manage context scope |
| `TaskRunnerAdviceHelperTest.scala` | Scala | 9 unit tests for extraction logic |

## Design
At `@Advice.OnMethodEnter`, `TaskContext.get()` is null (Spark sets it later inside `run()`). Instead, the advice reads `TaskRunner.taskDescription` via `@Advice.FieldValue` and accesses `TaskDescription.properties` via reflection (class is `private[spark]`).

The returned `Scope` is passed from enter to exit via `@Advice.Enter`, closing it restores the previous context.

## Test plan
- [x] 50 unit tests pass (9 new + 41 existing)
- [x] `sbt assembly` — both InstrumentationModule classes in SPI file
- [x] Docker e2e WITH `spark.plugins` — 611 spans (9 driver + 602 executor), no duplicates
- [x] Docker e2e WITHOUT `spark.plugins` — 613 spans (11 driver + 602 executor), ByteBuddy-only path works