### PR TITLE
Per-stage traceparent injection via DAGScheduler.submitMissingTasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Per-stage traceparent injection** — `SubmitMissingTasksInstrumentation` hooks
+  `DAGScheduler.submitMissingTasks(stage, jobId)` via ByteBuddy to inject a per-stage
+  traceparent into `ActiveJob.properties` before tasks are created. Executor task spans now
+  nest under their specific stage span (`app → job → stage → task`). Captures ALL stages
+  including AQE (Adaptive Query Execution) sub-jobs that bypass `SparkContext.runJob`.
+  Job and stage spans are pre-created via reflection on DAGScheduler internals, then adopted
+  by `TracingSparkListener` when `onJobStart`/`onStageSubmitted` fire. Backward compatible
+  with SparkPlugin-only mode ([#26])
 - **ByteBuddy TaskRunner context restoration** — `TaskRunnerInstrumentationModule` hooks
   `Executor$TaskRunner.run()` to extract `traceparent` from `TaskDescription.properties`
   and make the parent OTEL context current for the entire task execution. Downstream
@@ -102,3 +110,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#9]: https://github.com/Neutrinic/flare/issues/9
 [#14]: https://github.com/Neutrinic/flare/issues/14
 [#15]: https://github.com/Neutrinic/flare/issues/15
+[#26]: https://github.com/Neutrinic/flare/issues/26

--- a/README.md
+++ b/README.md
@@ -3,31 +3,34 @@
 OpenTelemetry distributed tracing for Apache Spark — driver-to-executor context propagation.
 
 ```
-spark.application  (driver, root)
-├── spark.job.0    (driver)
-│   └── spark.stage.0  (driver)
-├── spark.job.1    (driver)
-│   └── spark.stage.2  (driver)
-├── spark.task.executor  (executor-1, partition 0)  ← Flare
-├── spark.task.executor  (executor-1, partition 1)  ← Flare
-├── spark.task.executor  (executor-2, partition 2)  ← Flare
-└── spark.task.executor  (executor-2, partition 3)  ← Flare
+spark.application                                    (driver)
+├── spark.sql.0                                      (driver)
+│   ├── spark.job.0                                  (driver)
+│   │   └── spark.stage.0                            (driver)
+│   │       ├── spark.task.executor  (executor-1)    ← Flare
+│   │       └── spark.task.executor  (executor-2)    ← Flare
+│   └── spark.job.1                                  (driver)
+│       └── spark.stage.2                            (driver)
+│           ├── spark.task.executor  (executor-1)    ← Flare
+│           └── spark.task.executor  (executor-2)    ← Flare
+└── spark.sql.1                                      (driver)
+    └── spark.job.2                                  (driver)
+        └── spark.stage.4                            (driver)
+            ├── spark.task.executor  (executor-1)    ← Flare
+            └── spark.task.executor  (executor-2)    ← Flare
 ```
-
-> **Phase 1 note:** Task spans are children of the application span, not of their specific
-> job or stage. The traceparent is injected once at SparkContext init, pointing to the
-> application span. Phase 2 will inject per-job traceparent via ByteBuddy for full
-> hierarchical nesting.
 
 ## Overview
 
 Most Spark observability stops at the driver. You get a stage span with an aggregate duration but cannot see which executor ran slow, which partition was skewed, or whether a retry happened on a specific node.
 
-Flare injects a W3C `traceparent` into Spark's `LocalProperty` mechanism at SparkContext init. Local properties serialize into `TaskDescription` and travel to the executor JVM. `ExecutorPlugin.onTaskStart()` extracts the context and creates a real executor-side span with accurate wall-clock timing and the driver trace as parent.
+Flare hooks `DAGScheduler.submitMissingTasks` via ByteBuddy to inject a per-stage W3C `traceparent` into task properties before tasks are created. On the executor, the traceparent is extracted and restored as OTEL context, creating task spans with accurate wall-clock timing nested under their specific stage span. The full hierarchy — `app → sql → job → stage → task` — spans two JVM services with zero orphan spans.
 
 ## Features
 
+- **Full span hierarchy** — `app → sql → job → stage → task` across driver and executor JVMs
 - **Executor task spans** — real spans on the executor thread, not driver-side approximations
+- **Per-stage context** — each task inherits its specific stage span as parent, including AQE sub-jobs
 - **W3C trace continuity** — `traceparent` propagated via Spark's local property channel
 - **Zero code changes** — two JARs, two `--conf` lines on `spark-submit`
 - **OTEL native** — OTLP export to any backend (Grafana Tempo, Jaeger, Honeycomb, Datadog)
@@ -109,20 +112,30 @@ Open Grafana at `http://localhost:3000` — navigate to Explore, select Tempo, a
 ## Architecture
 
 ```
-FlareSparkPlugin
-├── FlareDriverPlugin          # creates application span, injects traceparent,
-│   └── TracingSparkListener   # registers listener for job/stage/SQL spans
-└── FlareExecutorPlugin        # extracts traceparent on executor, creates task spans
+ByteBuddy (OTEL agent extension)
+├── SparkContextInstrumentation        # auto-registers listener + executor plugin
+├── SubmitMissingTasksInstrumentation  # hooks DAGScheduler.submitMissingTasks
+│   └── SubmitMissingTasksAdviceHelper # creates job/stage spans, injects traceparent
+├── TaskRunnerInstrumentation          # hooks Executor$TaskRunner.run()
+│   └── TaskRunnerAdviceHelper         # extracts traceparent, restores OTEL context
+└── TracingSparkListener               # adopts pre-created spans, manages lifecycle
+
+FlareSparkPlugin (backward compat)
+├── FlareDriverPlugin                  # fallback when ByteBuddy is not active
+└── FlareExecutorPlugin                # creates task spans on executor
 ```
 
 Context propagation path:
 
 ```
-Driver: SparkContext.setLocalProperty("traceparent", "00-{traceId}-{spanId}-01")
-  → serialized into TaskDescription.properties
+Driver: DAGScheduler.submitMissingTasks(stage, jobId)
+  → ByteBuddy advice creates stage span
+  → injects traceparent into ActiveJob.properties
+  → properties serialized into TaskDescription
   → sent to executor JVM
-Executor: TaskContext.getLocalProperty("traceparent")
-  → W3C extract → parent context → span with accurate executor-side timing
+Executor: TaskRunner.run() / ExecutorPlugin.onTaskStart()
+  → extracts traceparent from task properties
+  → restores OTEL context → task span with executor-side timing
 ```
 
 ## Stack

--- a/examples/src/main/scala/io/flare/examples/SimpleJob.scala
+++ b/examples/src/main/scala/io/flare/examples/SimpleJob.scala
@@ -17,7 +17,6 @@ import org.apache.spark.sql.functions._
  *           └── spark.task.executor (partition 3 — executor-2)
  *
  * The task spans are created on the executor JVM with the driver trace as parent.
- * This is what no other open-source OTEL Spark integration provides.
  */
 object SimpleJob {
   def main(args: Array[String]): Unit = {

--- a/examples/src/main/scala/io/flare/examples/SkewedJob.scala
+++ b/examples/src/main/scala/io/flare/examples/SkewedJob.scala
@@ -7,14 +7,13 @@ import org.apache.spark.sql.functions._
  * Skewed partition example — the hero demo for Flare.
  *
  * Intentionally creates severe partition skew: one partition gets ~90% of the data,
- * the rest share 10%. In a driver-side-only tool (Spot, metrics-only APMs), the stage
- * span shows a single aggregate duration — you cannot see which partition is slow.
+ * the rest share 10%. With driver-side-only metrics, the stage span shows a single
+ * aggregate duration — you cannot see which partition is slow.
  *
  * With Flare, each executor task span shows its actual wall-clock duration on the
  * executor thread. In Grafana you immediately see one span taking 10x longer than
  * its siblings, on a specific executor, with the partition ID as an attribute.
  *
- * This is the trace you should screenshot for the README.
  */
 object SkewedJob {
   def main(args: Array[String]): Unit = {

--- a/src/main/java/io/flare/spark/instrumentation/SparkContextInstrumentationModule.java
+++ b/src/main/java/io/flare/spark/instrumentation/SparkContextInstrumentationModule.java
@@ -3,7 +3,7 @@ package io.flare.spark.instrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -33,7 +33,10 @@ public class SparkContextInstrumentationModule
 
     @Override
     public List<TypeInstrumentation> typeInstrumentations() {
-        return Collections.singletonList(new SparkContextInstrumentation());
+        return Arrays.asList(
+            new SparkContextInstrumentation(),
+            new SubmitMissingTasksInstrumentation()
+        );
     }
 
     /**

--- a/src/main/java/io/flare/spark/instrumentation/SubmitMissingTasksAdvice.java
+++ b/src/main/java/io/flare/spark/instrumentation/SubmitMissingTasksAdvice.java
@@ -1,0 +1,27 @@
+package io.flare.spark.instrumentation;
+
+import net.bytebuddy.asm.Advice;
+
+/**
+ * ByteBuddy advice for {@code DAGScheduler.submitMissingTasks(stage, jobId)}.
+ *
+ * <p>On method enter: creates a per-stage span, injects its W3C traceparent
+ * into {@code ActiveJob.properties} so that tasks created during this method
+ * inherit the stage-level trace context on the executor.
+ *
+ * <p>No exit advice is needed — the properties mutation is consumed by the
+ * method body when it creates the TaskSet.
+ *
+ * <p>Written in Java for reliable bytecode inlining. All real logic lives in
+ * {@link SubmitMissingTasksAdviceHelper}.
+ */
+public class SubmitMissingTasksAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(
+            @Advice.This Object dagScheduler,
+            @Advice.Argument(0) Object stage,
+            @Advice.Argument(1) int jobId) {
+        SubmitMissingTasksAdviceHelper.onEnter(dagScheduler, stage, jobId);
+    }
+}

--- a/src/main/java/io/flare/spark/instrumentation/SubmitMissingTasksInstrumentation.java
+++ b/src/main/java/io/flare/spark/instrumentation/SubmitMissingTasksInstrumentation.java
@@ -1,0 +1,36 @@
+package io.flare.spark.instrumentation;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * TypeInstrumentation targeting {@code DAGScheduler.submitMissingTasks(stage, jobId)}.
+ *
+ * <p>This is where Spark creates tasks for a specific stage. By hooking here,
+ * we inject a per-stage traceparent into {@code ActiveJob.properties} before
+ * tasks are created, making executor task spans children of their stage span.
+ *
+ * <p>Unlike the previous {@code runJob} hook, this captures ALL stages including
+ * AQE (Adaptive Query Execution) sub-jobs that bypass {@code SparkContext.runJob}.
+ *
+ * <p>Written in Java because the agent's extension classloader does not have
+ * the Scala runtime.
+ */
+public class SubmitMissingTasksInstrumentation implements TypeInstrumentation {
+
+    @Override
+    public ElementMatcher<TypeDescription> typeMatcher() {
+        return ElementMatchers.named("org.apache.spark.scheduler.DAGScheduler");
+    }
+
+    @Override
+    public void transform(TypeTransformer transformer) {
+        transformer.applyAdviceToMethod(
+            ElementMatchers.named("submitMissingTasks"),
+            SubmitMissingTasksAdvice.class.getName()
+        );
+    }
+}

--- a/src/main/scala/io/flare/spark/instrumentation/SubmitMissingTasksAdviceHelper.scala
+++ b/src/main/scala/io/flare/spark/instrumentation/SubmitMissingTasksAdviceHelper.scala
@@ -1,0 +1,220 @@
+package io.flare.spark.instrumentation
+
+import io.flare.spark.plugin.FlareDriverState
+import io.flare.spark.propagation.LocalPropertyPropagator
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.{Span, SpanKind, StatusCode}
+import io.opentelemetry.context.Context
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.logging.{Level, Logger}
+
+/**
+ * Scala delegation target for [[SubmitMissingTasksAdvice]].
+ *
+ * Hooks `DAGScheduler.submitMissingTasks(stage, jobId)` to inject a per-stage
+ * traceparent into `ActiveJob.properties` before tasks are created. This makes
+ * executor task spans children of their specific stage span:
+ *
+ * {{{
+ *   spark.application
+ *   └── spark.job.{id}
+ *       └── spark.stage.{id}
+ *           └── spark.task.executor   (on executor JVM)
+ * }}}
+ *
+ * Unlike the previous `runJob` hook, this captures ALL stages — including
+ * AQE (Adaptive Query Execution) sub-jobs that bypass `SparkContext.runJob`.
+ *
+ * Job spans are created on first access per jobId (via `computeIfAbsent`)
+ * and stage spans are created per `submitMissingTasks` call. Both are stored
+ * for adoption by [[io.flare.spark.listener.TracingSparkListener]] when
+ * `onJobStart` / `onStageSubmitted` fire on the listener bus.
+ *
+ * Reflection is used to access `DAGScheduler.jobIdToActiveJob(jobId).properties`
+ * because `DAGScheduler` and `ActiveJob` are `private[scheduler]`.
+ *
+ * IMPORTANT: Uses `java.util.logging` (not SLF4J) because at advice execution
+ * time, SLF4J may not be fully initialized in the agent's extension classloader.
+ */
+object SubmitMissingTasksAdviceHelper {
+
+  private val logger = Logger.getLogger(classOf[SubmitMissingTasksAdviceHelper.type].getName)
+
+  /**
+   * Job spans keyed by jobId. Created on first `submitMissingTasks` call for a
+   * given jobId. The listener's `onJobStart` reads (but does not remove) the span
+   * via [[getJobSpan]]; the listener's `onJobEnd` removes it via [[removeJobSpan]].
+   */
+  private[spark] val jobSpans = new ConcurrentHashMap[Int, Span]()
+
+  /**
+   * Pending stage spans keyed by stageId. Created per `submitMissingTasks` call,
+   * adopted (removed) by the listener at `onStageSubmitted` via [[adoptPendingStageSpan]].
+   */
+  private[spark] val pendingStageSpans = new ConcurrentHashMap[Int, Span]()
+
+  /**
+   * Active SQL execution spans keyed by executionId. Managed by the listener's
+   * `onOtherEvent` (SQL start/end). Shared here so the advice can parent job spans
+   * under their SQL execution when `spark.sql.execution.id` is present in job properties.
+   */
+  private[spark] val activeSQLSpans = new ConcurrentHashMap[Long, Span]()
+
+  // ── Cached reflection accessors ────────────────────────────────────────────
+
+  @volatile private var reflectionReady = false
+  private var jobIdToActiveJobField: java.lang.reflect.Field = _
+  private var stageIdMethod: java.lang.reflect.Method = _
+  private var propertiesMethod: java.lang.reflect.Method = _
+
+  private def ensureReflection(dagScheduler: Any): Boolean = {
+    if (reflectionReady) return true
+    synchronized {
+      if (reflectionReady) return true
+      try {
+        // DAGScheduler.jobIdToActiveJob — private val, Scala mutable.HashMap
+        val dsClass = dagScheduler.getClass
+        val fields = dsClass.getDeclaredFields
+        jobIdToActiveJobField = fields.find(_.getName == "jobIdToActiveJob")
+          .orElse(fields.find(_.getName.contains("jobIdToActiveJob")))
+          .getOrElse(throw new NoSuchFieldException(
+            s"jobIdToActiveJob not found in ${dsClass.getName}"))
+        jobIdToActiveJobField.setAccessible(true)
+
+        // Stage.id — public getter inherited from abstract Stage
+        stageIdMethod = Class.forName("org.apache.spark.scheduler.Stage")
+          .getMethod("id")
+
+        // ActiveJob.properties — public getter on package-private class
+        propertiesMethod = Class.forName("org.apache.spark.scheduler.ActiveJob")
+          .getMethod("properties")
+
+        reflectionReady = true
+        logger.info("[Flare] DAGScheduler reflection initialized successfully")
+        true
+      } catch {
+        case e: Exception =>
+          logger.log(Level.WARNING,
+            "[Flare] Reflection init failed for DAGScheduler instrumentation", e)
+          false
+      }
+    }
+  }
+
+  // ── Advice entry point ────────────────────────────────────────────────────
+
+  /**
+   * Called from `@Advice.OnMethodEnter` on `DAGScheduler.submitMissingTasks(stage, jobId)`.
+   *
+   * 1. Looks up `ActiveJob.properties` via reflection
+   * 2. Gets or creates a job span for the jobId
+   * 3. Creates a stage span under the job span
+   * 4. Injects the stage span's W3C traceparent into the properties
+   */
+  def onEnter(dagScheduler: Any, stage: Any, jobId: Int): Unit = {
+    try {
+      if (!ensureReflection(dagScheduler)) return
+
+      val appSpan = FlareDriverState.applicationSpan match {
+        case Some(span) => span
+        case None => return
+      }
+
+      // Get stageId from the Stage argument
+      val stageId = stageIdMethod.invoke(stage).asInstanceOf[java.lang.Integer].intValue()
+
+      // Get ActiveJob.properties via reflection on DAGScheduler internals
+      val jobMap = jobIdToActiveJobField.get(dagScheduler)
+        .asInstanceOf[scala.collection.mutable.Map[Int, AnyRef]]
+      val activeJob = jobMap.get(jobId).orNull
+      if (activeJob == null) {
+        logger.fine(s"[Flare] No ActiveJob for jobId=$jobId, skipping")
+        return
+      }
+      val props = propertiesMethod.invoke(activeJob).asInstanceOf[java.util.Properties]
+      if (props == null) return
+
+      val tracer = GlobalOpenTelemetry.getTracer("io.flare.spark")
+
+      // Get or create job span for this jobId (first stage creates it).
+      // Use putIfAbsent to handle the race where the listener's onJobStart
+      // may have already created and stored a span for this jobId.
+      var jobSpan = jobSpans.get(jobId)
+      if (jobSpan == null) {
+        // Determine parent: SQL span if job is SQL-triggered, otherwise app span.
+        // Spark sets spark.sql.execution.id in ActiveJob.properties for SQL jobs.
+        val parentSpan = Option(props.getProperty("spark.sql.execution.id"))
+          .flatMap(id => try Some(id.toLong) catch { case _: NumberFormatException => None })
+          .map(id => activeSQLSpans.get(id))
+          .flatMap(Option(_))
+          .getOrElse(appSpan)
+
+        val parentCtx = Context.root().`with`(parentSpan)
+        val newSpan = tracer
+          .spanBuilder(s"spark.job.$jobId")
+          .setSpanKind(SpanKind.INTERNAL)
+          .setParent(parentCtx)
+          .startSpan()
+        val existing = jobSpans.putIfAbsent(jobId, newSpan)
+        if (existing != null) {
+          // Listener already created a span for this jobId — discard ours
+          newSpan.end()
+          jobSpan = existing
+        } else {
+          jobSpan = newSpan
+        }
+      }
+
+      // Create stage span as child of job span
+      val stageParentCtx = Context.root().`with`(jobSpan)
+      val stageSpan = tracer
+        .spanBuilder(s"spark.stage.$stageId")
+        .setSpanKind(SpanKind.INTERNAL)
+        .setParent(stageParentCtx)
+        .startSpan()
+
+      // Handle superseded stage spans (stage retries with same stageId)
+      val superseded = pendingStageSpans.put(stageId, stageSpan)
+      if (superseded != null) {
+        superseded.setStatus(StatusCode.ERROR, "Superseded by stage retry")
+        superseded.end()
+      }
+
+      // Inject stage span's traceparent into ActiveJob.properties.
+      // The method body reads these properties and passes them to the TaskSet,
+      // so tasks inherit the stage-level context on the executor.
+      val stageCtx = Context.root().`with`(stageSpan)
+      LocalPropertyPropagator.injectIntoProperties(stageCtx, props)
+
+      logger.fine(s"[Flare] submitMissingTasks: jobId=$jobId stageId=$stageId traceparent injected")
+    } catch {
+      case e: Exception =>
+        logger.log(Level.FINE, "[Flare] submitMissingTasks advice failed", e)
+    }
+  }
+
+  // ── Listener adoption methods ─────────────────────────────────────────────
+
+  /**
+   * Called by [[io.flare.spark.listener.TracingSparkListener]] at `onJobStart`
+   * to get the pre-created job span. Does NOT remove the span — it stays in the
+   * map for subsequent `submitMissingTasks` calls that need it as stage parent.
+   */
+  def getJobSpan(jobId: Int): Option[Span] =
+    Option(jobSpans.get(jobId))
+
+  /**
+   * Called by [[io.flare.spark.listener.TracingSparkListener]] at `onJobEnd`
+   * to remove the job span from the map after it has been ended.
+   */
+  def removeJobSpan(jobId: Int): Option[Span] =
+    Option(jobSpans.remove(jobId))
+
+  /**
+   * Called by [[io.flare.spark.listener.TracingSparkListener]] at `onStageSubmitted`
+   * to adopt the pre-created stage span. Removes the span from the pending map.
+   */
+  def adoptPendingStageSpan(stageId: Int): Option[Span] =
+    Option(pendingStageSpans.remove(stageId))
+}

--- a/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
+++ b/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
@@ -3,6 +3,7 @@ package io.flare.spark.listener
 import io.flare.spark.SpanCompat._
 import io.flare.spark.attributes.SparkAttributes._
 import io.flare.spark.config.FlareConfig
+import io.flare.spark.instrumentation.SubmitMissingTasksAdviceHelper
 import io.opentelemetry.api.trace.{Span, SpanKind, StatusCode, Tracer}
 import io.opentelemetry.context.Context
 import org.apache.spark.scheduler._
@@ -37,7 +38,6 @@ class TracingSparkListener(
   // All maps use TrieMap for thread safety (LiveListenerBus may change threading model)
   private val activeJobSpans:   TrieMap[Int, Span]  = TrieMap.empty
   private val activeStageSpans: TrieMap[Int, Span]  = TrieMap.empty
-  private val activeSQLSpans:   TrieMap[Long, Span] = TrieMap.empty
 
   // Reverse index: stageId → jobId, built at onJobStart from jobStart.stageIds
   // Critical for correct parent attribution when multiple jobs run concurrently
@@ -68,15 +68,46 @@ class TracingSparkListener(
 
   override def onJobStart(event: SparkListenerJobStart): Unit =
     if (config.tracesJobs) safeHandle("onJobStart") {
-      val parentContext = applicationSpan
-        .map(Context.current().`with`)
-        .getOrElse(Context.current())
+      // Check if SubmitMissingTasksAdvice pre-created a job span for this jobId.
+      // The advice hooks DAGScheduler.submitMissingTasks and creates the job span
+      // on first call for a given jobId. We adopt (get, don't remove) it here.
+      //
+      // Race condition: onJobStart fires async on the listener bus. The advice's
+      // submitMissingTasks may or may not have run yet. Both sides use putIfAbsent
+      // on the shared jobSpans map so only ONE span wins per jobId.
+      val span = SubmitMissingTasksAdviceHelper.getJobSpan(event.jobId) match {
+        case Some(preCreated) =>
+          logger.debug(s"[Flare] Job ${event.jobId} adopted pre-created span")
+          preCreated
 
-      val span = tracer
-        .spanBuilder(s"spark.job.${event.jobId}")
-        .setSpanKind(SpanKind.INTERNAL)
-        .setParent(parentContext)
-        .startSpan()
+        case None =>
+          // No pre-created span yet. Create one and store it in the helper's map
+          // via putIfAbsent. If the advice races us and stores first, we discard ours.
+          // Parent under SQL span if this job was triggered by a SQL execution.
+          val sqlParent = Option(event.properties)
+            .flatMap(p => Option(p.getProperty("spark.sql.execution.id")))
+            .flatMap(id => try Some(id.toLong) catch { case _: NumberFormatException => None })
+            .flatMap(id => Option(SubmitMissingTasksAdviceHelper.activeSQLSpans.get(id)))
+
+          val parentContext = sqlParent.orElse(applicationSpan)
+            .map(Context.current().`with`)
+            .getOrElse(Context.current())
+
+          val newSpan = tracer
+            .spanBuilder(s"spark.job.${event.jobId}")
+            .setSpanKind(SpanKind.INTERNAL)
+            .setParent(parentContext)
+            .startSpan()
+
+          val existing = SubmitMissingTasksAdviceHelper.jobSpans.putIfAbsent(event.jobId, newSpan)
+          if (existing != null) {
+            // Advice created a span between our get and putIfAbsent — use theirs
+            newSpan.end()
+            existing
+          } else {
+            newSpan
+          }
+      }
 
       span.setLong(Job.Id, event.jobId.toLong)
       span.setLong(Job.StageCount, event.stageIds.size.toLong)
@@ -97,6 +128,9 @@ class TracingSparkListener(
     // Always clean up stageToJob, even if the job span was missed.
     // This prevents unbounded growth if onJobStart was lost due to listener registration timing.
     stageToJob.filterInPlace { case (_, jobId) => jobId != event.jobId }
+
+    // Clean up pre-created job span from the helper's map
+    SubmitMissingTasksAdviceHelper.removeJobSpan(event.jobId)
 
     activeJobSpans.remove(event.jobId).foreach { span =>
       safeHandle("onJobEnd") {
@@ -122,29 +156,38 @@ class TracingSparkListener(
     if (config.tracesStages) safeHandle("onStageSubmitted") {
       val stageId = event.stageInfo.stageId
 
-      // Correct attribution: look up this stage's job, then that job's span
-      val parentSpan: Option[Span] =
-        stageToJob.get(stageId).flatMap(activeJobSpans.get).orElse(applicationSpan)
+      // Check if SubmitMissingTasksAdvice pre-created a stage span
+      val span = SubmitMissingTasksAdviceHelper.adoptPendingStageSpan(stageId) match {
+        case Some(preCreated) =>
+          logger.debug(s"[Flare] Stage $stageId adopted pre-created span")
+          preCreated
 
-      parentSpan match {
         case None =>
-          logger.warn(s"[Flare] No parent span found for stage $stageId, skipping")
+          // No pre-created span — create as before (backward-compat / SparkPlugin-only)
+          val parentSpan: Option[Span] =
+            stageToJob.get(stageId).flatMap(activeJobSpans.get).orElse(applicationSpan)
 
-        case Some(parent) =>
-          val span = tracer
-            .spanBuilder(s"spark.stage.${stageId}")
-            .setSpanKind(SpanKind.INTERNAL)
-            .setParent(Context.current().`with`(parent))
-            .startSpan()
+          parentSpan match {
+            case None =>
+              logger.warn(s"[Flare] No parent span found for stage $stageId, skipping")
+              return
 
-          span.setLong(Stage.Id, stageId.toLong)
-          span.setLong(Stage.AttemptId, event.stageInfo.attemptNumber().toLong)
-          span.setAttribute(Stage.Name, event.stageInfo.name)
-          span.setLong(Stage.TaskCount, event.stageInfo.numTasks.toLong)
-
-          activeStageSpans.put(stageId, span)
-          logger.debug(s"[Flare] Stage $stageId submitted")
+            case Some(parent) =>
+              tracer
+                .spanBuilder(s"spark.stage.$stageId")
+                .setSpanKind(SpanKind.INTERNAL)
+                .setParent(Context.current().`with`(parent))
+                .startSpan()
+          }
       }
+
+      span.setLong(Stage.Id, stageId.toLong)
+      span.setLong(Stage.AttemptId, event.stageInfo.attemptNumber().toLong)
+      span.setAttribute(Stage.Name, event.stageInfo.name)
+      span.setLong(Stage.TaskCount, event.stageInfo.numTasks.toLong)
+
+      activeStageSpans.put(stageId, span)
+      logger.debug(s"[Flare] Stage $stageId submitted")
     }
 
   override def onStageCompleted(event: SparkListenerStageCompleted): Unit = {
@@ -190,14 +233,16 @@ class TracingSparkListener(
               .setSpanKind(SpanKind.INTERNAL)
               .setParent(Context.current().`with`(parent))
               .startSpan()
-            activeSQLSpans.put(e.executionId, span)
+            // Store in shared map so advice and onJobStart can parent jobs under SQL
+            SubmitMissingTasksAdviceHelper.activeSQLSpans.put(e.executionId, span)
           }
         }
         case e: SparkListenerSQLExecutionEnd => safeHandle("onSQLEnd") {
-          activeSQLSpans.remove(e.executionId).foreach { span =>
-            span.setStatus(StatusCode.OK)
-            span.end()
-          }
+          Option(SubmitMissingTasksAdviceHelper.activeSQLSpans.remove(e.executionId))
+            .foreach { span =>
+              span.setStatus(StatusCode.OK)
+              span.end()
+            }
         }
         case _ =>
       }
@@ -207,8 +252,12 @@ class TracingSparkListener(
 
   def shutdown(): Unit = {
     logger.info("[Flare] Shutting down listener, ending any open spans")
-    Seq[TrieMap[_, Span]](activeStageSpans, activeJobSpans, activeSQLSpans)
+    Seq[TrieMap[_, Span]](activeStageSpans, activeJobSpans)
       .foreach { m => m.values.foreach(_.end()); m.clear() }
+    // End any open SQL spans from the shared map
+    val sqlSpans = SubmitMissingTasksAdviceHelper.activeSQLSpans
+    sqlSpans.values().forEach(_.end())
+    sqlSpans.clear()
     applicationSpan.foreach(_.end())
     stageToJob.clear()
   }

--- a/src/main/scala/io/flare/spark/plugin/FlareDriverPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareDriverPlugin.scala
@@ -25,10 +25,10 @@ import java.{util => ju}
  * This runs inside DriverPlugin.init(), which fires during SparkContext construction
  * after the LiveListenerBus is started but before any jobs are submitted.
  *
- * Phase 1 limitation: traceparent is injected once (pointing to the application span).
- * All executor task spans will be children of the application span, not of their
- * specific job/stage span. Phase 2 (ByteBuddy hooking runJob) will inject per-job
- * traceparent for full hierarchical nesting.
+ * The traceparent injected here points to the application span. When ByteBuddy is active,
+ * [[io.flare.spark.instrumentation.RunJobAdviceHelper]] temporarily overrides it at each
+ * `runJob` call with a per-job traceparent, giving executor tasks the correct job span as
+ * parent. Without ByteBuddy, all tasks fall back to being children of the application span.
  */
 class FlareDriverPlugin extends DriverPlugin {
 

--- a/src/main/scala/io/flare/spark/plugin/FlareDriverState.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareDriverState.scala
@@ -26,7 +26,7 @@ object FlareDriverState {
   private val logger = Logger.getLogger(classOf[FlareDriverState.type].getName)
 
   @volatile private var _initialized: Boolean = false
-  @volatile private[plugin] var applicationSpan: Option[Span] = None
+  @volatile private[spark] var applicationSpan: Option[Span] = None
   @volatile private var listener: Option[TracingSparkListener] = None
 
   /** Read-only access to initialization state. */

--- a/src/main/scala/io/flare/spark/propagation/LocalPropertyPropagator.scala
+++ b/src/main/scala/io/flare/spark/propagation/LocalPropertyPropagator.scala
@@ -8,6 +8,7 @@ import org.apache.spark.TaskContext
 import org.slf4j.LoggerFactory
 
 import java.{util => ju}
+import java.util.Properties
 
 /**
  * Injects and extracts W3C traceparent/tracestate via Spark's LocalProperty mechanism.
@@ -56,6 +57,17 @@ object LocalPropertyPropagator {
   }
 
   /**
+   * Inject OTEL context directly into a `java.util.Properties` instance.
+   *
+   * Used by `SubmitMissingTasksAdviceHelper` to inject per-stage traceparent
+   * into `ActiveJob.properties` before tasks are created.
+   */
+  def injectIntoProperties(context: OtelContext, props: Properties): Unit = {
+    val propagator = GlobalOpenTelemetry.getPropagators.getTextMapPropagator
+    propagator.inject(context, props, PropertiesSetter)
+  }
+
+  /**
    * Extract OTEL parent context from a raw `java.util.Properties` instance.
    *
    * Used by `TaskRunnerAdviceHelper` where `TaskContext` is not yet available —
@@ -86,6 +98,13 @@ object LocalPropertyPropagator {
       override def get(carrier: TaskContext, key: String): String =
         if (carrier == null) null
         else carrier.getLocalProperty(key)
+    }
+
+  // ── TextMapSetter for java.util.Properties ────────────────────────────────
+
+  private val PropertiesSetter: TextMapSetter[Properties] =
+    (carrier: Properties, key: String, value: String) => {
+      carrier.setProperty(key, value)
     }
 
   // ── TextMapGetter for java.util.Properties ────────────────────────────────

--- a/src/test/scala/io/flare/spark/instrumentation/SubmitMissingTasksAdviceHelperTest.scala
+++ b/src/test/scala/io/flare/spark/instrumentation/SubmitMissingTasksAdviceHelperTest.scala
@@ -1,0 +1,136 @@
+package io.flare.spark.instrumentation
+
+import io.opentelemetry.api.trace.{Span, SpanKind, Tracer}
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
+import munit.FunSuite
+
+/**
+ * Unit tests for [[SubmitMissingTasksAdviceHelper]].
+ *
+ * Tests the pending span adoption mechanics (store, adopt, cleanup) without
+ * requiring a real DAGScheduler. Full integration tests with SparkSession
+ * verify the end-to-end span hierarchy.
+ */
+class SubmitMissingTasksAdviceHelperTest extends FunSuite {
+
+  private val exporter = InMemorySpanExporter.create()
+
+  private val tracerProvider: SdkTracerProvider = SdkTracerProvider.builder()
+    .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+    .build()
+
+  private val tracer: Tracer = tracerProvider.get("test")
+
+  override def afterAll(): Unit = {
+    tracerProvider.shutdown()
+    super.afterAll()
+  }
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    exporter.reset()
+    SubmitMissingTasksAdviceHelper.jobSpans.clear()
+    SubmitMissingTasksAdviceHelper.pendingStageSpans.clear()
+    SubmitMissingTasksAdviceHelper.activeSQLSpans.clear()
+    super.beforeEach(context)
+  }
+
+  // ── Helper ────────────────────────────────────────────────────────────────
+
+  private def createTestSpan(name: String = "test.span"): Span =
+    tracer.spanBuilder(name)
+      .setSpanKind(SpanKind.INTERNAL)
+      .startSpan()
+
+  // ── Tests: getJobSpan / removeJobSpan ───────────────────────────────────
+
+  test("getJobSpan returns the stored span without removing it") {
+    val span = createTestSpan("spark.job.0")
+    SubmitMissingTasksAdviceHelper.jobSpans.put(0, span)
+
+    val first = SubmitMissingTasksAdviceHelper.getJobSpan(0)
+    assert(first.isDefined, "First call should return Some(span)")
+    assertEquals(first.get.getSpanContext.getSpanId, span.getSpanContext.getSpanId)
+
+    // Second call should ALSO return the span (not removed)
+    val second = SubmitMissingTasksAdviceHelper.getJobSpan(0)
+    assert(second.isDefined, "Second call should still return Some(span)")
+  }
+
+  test("getJobSpan returns None for unknown jobId") {
+    val result = SubmitMissingTasksAdviceHelper.getJobSpan(999)
+    assert(result.isEmpty)
+  }
+
+  test("removeJobSpan removes and returns the span") {
+    val span = createTestSpan("spark.job.1")
+    SubmitMissingTasksAdviceHelper.jobSpans.put(1, span)
+
+    val removed = SubmitMissingTasksAdviceHelper.removeJobSpan(1)
+    assert(removed.isDefined)
+    assertEquals(removed.get.getSpanContext.getSpanId, span.getSpanContext.getSpanId)
+
+    // After removal, getJobSpan should return None
+    val after = SubmitMissingTasksAdviceHelper.getJobSpan(1)
+    assert(after.isEmpty, "Should be None after removal")
+  }
+
+  // ── Tests: adoptPendingStageSpan ────────────────────────────────────────
+
+  test("adoptPendingStageSpan returns and removes the stored span") {
+    val span = createTestSpan("spark.stage.10")
+    SubmitMissingTasksAdviceHelper.pendingStageSpans.put(10, span)
+
+    val result = SubmitMissingTasksAdviceHelper.adoptPendingStageSpan(10)
+    assert(result.isDefined)
+    assertEquals(result.get.getSpanContext.getSpanId, span.getSpanContext.getSpanId)
+
+    // Second call should return None (already adopted)
+    val second = SubmitMissingTasksAdviceHelper.adoptPendingStageSpan(10)
+    assert(second.isEmpty, "Second call should return None")
+  }
+
+  test("adoptPendingStageSpan returns None for unknown stageId") {
+    val result = SubmitMissingTasksAdviceHelper.adoptPendingStageSpan(999)
+    assert(result.isEmpty)
+  }
+
+  // ── Tests: multiple jobs and stages ─────────────────────────────────────
+
+  test("multiple jobs are independent") {
+    val span0 = createTestSpan("spark.job.0")
+    val span1 = createTestSpan("spark.job.1")
+    SubmitMissingTasksAdviceHelper.jobSpans.put(0, span0)
+    SubmitMissingTasksAdviceHelper.jobSpans.put(1, span1)
+
+    val result0 = SubmitMissingTasksAdviceHelper.getJobSpan(0)
+    val result1 = SubmitMissingTasksAdviceHelper.getJobSpan(1)
+    assert(result0.isDefined)
+    assert(result1.isDefined)
+    assertEquals(result0.get.getSpanContext.getSpanId, span0.getSpanContext.getSpanId)
+    assertEquals(result1.get.getSpanContext.getSpanId, span1.getSpanContext.getSpanId)
+  }
+
+  test("multiple stages for same job are independent") {
+    val stage10 = createTestSpan("spark.stage.10")
+    val stage11 = createTestSpan("spark.stage.11")
+    SubmitMissingTasksAdviceHelper.pendingStageSpans.put(10, stage10)
+    SubmitMissingTasksAdviceHelper.pendingStageSpans.put(11, stage11)
+
+    val result10 = SubmitMissingTasksAdviceHelper.adoptPendingStageSpan(10)
+    assert(result10.isDefined)
+    assertEquals(result10.get.getSpanContext.getSpanId, stage10.getSpanContext.getSpanId)
+
+    // Stage 11 should still be there
+    val result11 = SubmitMissingTasksAdviceHelper.adoptPendingStageSpan(11)
+    assert(result11.isDefined)
+    assertEquals(result11.get.getSpanContext.getSpanId, stage11.getSpanContext.getSpanId)
+  }
+
+  test("onEnter returns safely with null dagScheduler") {
+    // Should not throw — just silently skip
+    SubmitMissingTasksAdviceHelper.onEnter(null, null, 0)
+    assert(SubmitMissingTasksAdviceHelper.jobSpans.isEmpty)
+  }
+}

--- a/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
+++ b/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
@@ -2,6 +2,7 @@ package io.flare.spark.listener
 
 import io.flare.spark.attributes.SparkAttributes._
 import io.flare.spark.config.{FlareConfig, TraceGranularity}
+import io.flare.spark.instrumentation.SubmitMissingTasksAdviceHelper
 import io.opentelemetry.api.trace.{SpanKind, StatusCode}
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
@@ -35,6 +36,11 @@ class TracingSparkListenerTest extends FunSuite {
    * into the exporter before asserting.
    */
   def withListener(body: (TracingSparkListener, InMemorySpanExporter) => Unit): Unit = {
+    // Clean up shared state from previous tests
+    SubmitMissingTasksAdviceHelper.jobSpans.clear()
+    SubmitMissingTasksAdviceHelper.pendingStageSpans.clear()
+    SubmitMissingTasksAdviceHelper.activeSQLSpans.clear()
+
     val exporter = InMemorySpanExporter.create()
     val tracerProvider = SdkTracerProvider.builder()
       .addSpanProcessor(SimpleSpanProcessor.create(exporter))
@@ -48,7 +54,12 @@ class TracingSparkListenerTest extends FunSuite {
     listener.setApplicationSpan(appSpan)
 
     try body(listener, exporter)
-    finally tracerProvider.close()
+    finally {
+      tracerProvider.close()
+      SubmitMissingTasksAdviceHelper.jobSpans.clear()
+      SubmitMissingTasksAdviceHelper.pendingStageSpans.clear()
+      SubmitMissingTasksAdviceHelper.activeSQLSpans.clear()
+    }
   }
 
   // ── Event helpers using FlareTestHelpers for private[spark] access ──────────
@@ -224,6 +235,151 @@ class TracingSparkListenerTest extends FunSuite {
     }
   }
 
+  test("onJobStart adopts pre-created span from SubmitMissingTasksAdviceHelper") {
+    withListener { (listener, exporter) =>
+      // Simulate what SubmitMissingTasksAdvice does: pre-create a job span
+      // and register it by jobId.
+      val tracer = io.opentelemetry.sdk.trace.SdkTracerProvider.builder()
+        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+        .build().get("io.flare.spark.test")
+
+      val preCreatedSpan = tracer.spanBuilder("spark.job.42")
+        .setSpanKind(SpanKind.INTERNAL)
+        .startSpan()
+
+      SubmitMissingTasksAdviceHelper.jobSpans.put(42, preCreatedSpan)
+
+      listener.onJobStart(makeJobStart(42, Seq(0)))
+      listener.onJobEnd(makeJobEnd(42, succeeded = true))
+      listener.shutdown()
+
+      val spans = exporter.getFinishedSpanItems.asScala
+
+      // The adopted span should appear as "spark.job.42"
+      assert(spans.exists(_.getName == "spark.job.42"), "Adopted span should be present")
+
+      // The helper's map should be cleaned up after onJobEnd
+      assert(!SubmitMissingTasksAdviceHelper.jobSpans.containsKey(42))
+
+      // Clean up
+      SubmitMissingTasksAdviceHelper.jobSpans.clear()
+    }
+  }
+
+  test("onStageSubmitted adopts pre-created span from SubmitMissingTasksAdviceHelper") {
+    withListener { (listener, exporter) =>
+      val tracer = io.opentelemetry.sdk.trace.SdkTracerProvider.builder()
+        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+        .build().get("io.flare.spark.test")
+
+      // Pre-create a stage span (as the advice would do)
+      val preCreatedStage = tracer.spanBuilder("spark.stage.10")
+        .setSpanKind(SpanKind.INTERNAL)
+        .startSpan()
+
+      SubmitMissingTasksAdviceHelper.pendingStageSpans.put(10, preCreatedStage)
+
+      listener.onJobStart(makeJobStart(0, Seq(10)))
+      listener.onStageSubmitted(makeStageSubmitted(10))
+      listener.onStageCompleted(makeStageCompleted(10))
+      listener.onJobEnd(makeJobEnd(0, succeeded = true))
+      listener.shutdown()
+
+      val spans = exporter.getFinishedSpanItems.asScala
+
+      // The adopted stage span should appear
+      assert(spans.exists(_.getName == "spark.stage.10"), "Adopted stage span should be present")
+
+      // The pending map should be empty
+      assert(!SubmitMissingTasksAdviceHelper.pendingStageSpans.containsKey(10))
+
+      // Clean up
+      SubmitMissingTasksAdviceHelper.pendingStageSpans.clear()
+    }
+  }
+
+  test("onJobStart falls back to creating span when no pre-created span exists") {
+    withListener { (listener, exporter) =>
+      // No pre-created span — should create span normally (backward compat)
+      // The listener now stores the created span in the helper's jobSpans map
+      // via putIfAbsent so the advice can find it if it races.
+      listener.onJobStart(makeJobStart(0, Seq(0)))
+
+      // Verify the span was stored in the helper's map
+      assert(SubmitMissingTasksAdviceHelper.jobSpans.containsKey(0),
+        "Fallback span should be stored in helper's jobSpans map")
+
+      listener.onJobEnd(makeJobEnd(0, succeeded = true))
+      listener.shutdown()
+
+      val spans = exporter.getFinishedSpanItems.asScala
+      val appSpan = spans.find(_.getName == "spark.application").get
+      val jobSpan = spans.find(_.getName == "spark.job.0").get
+
+      assertEquals(jobSpan.getParentSpanId, appSpan.getSpanId)
+
+      // onJobEnd should have cleaned up the helper's map
+      assert(!SubmitMissingTasksAdviceHelper.jobSpans.containsKey(0))
+
+      // Clean up
+      SubmitMissingTasksAdviceHelper.jobSpans.clear()
+    }
+  }
+
+  test("SQL-triggered job is parented under SQL span") {
+    withListener { (listener, exporter) =>
+      // Simulate what the listener's onOtherEvent does for SQL start:
+      // create a SQL span and put it in the shared helper map.
+      val tracer = SdkTracerProvider.builder()
+        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+        .build().get("io.flare.spark.test")
+      val sqlSpan = tracer.spanBuilder("spark.sql.0")
+        .setSpanKind(SpanKind.INTERNAL)
+        .startSpan()
+      SubmitMissingTasksAdviceHelper.activeSQLSpans.put(0L, sqlSpan)
+
+      // Start a job with spark.sql.execution.id in its properties
+      val jobEvent = makeJobStart(0, Seq(0))
+      jobEvent.properties.setProperty("spark.sql.execution.id", "0")
+      listener.onJobStart(jobEvent)
+
+      listener.onStageSubmitted(makeStageSubmitted(0))
+      listener.onStageCompleted(makeStageCompleted(0))
+      listener.onJobEnd(makeJobEnd(0, succeeded = true))
+
+      // End the SQL span
+      sqlSpan.end()
+      SubmitMissingTasksAdviceHelper.activeSQLSpans.remove(0L)
+
+      listener.shutdown()
+
+      val spans = exporter.getFinishedSpanItems.asScala
+      val sqlSpanData = spans.find(_.getName == "spark.sql.0").get
+      val jobSpanData = spans.find(_.getName == "spark.job.0").get
+      val stgSpan = spans.find(_.getName == "spark.stage.0").get
+
+      // Job is child of SQL (not app)
+      assertEquals(jobSpanData.getParentSpanId, sqlSpanData.getSpanId)
+      // Stage is child of job
+      assertEquals(stgSpan.getParentSpanId, jobSpanData.getSpanId)
+    }
+  }
+
+  test("non-SQL job is parented under app span") {
+    withListener { (listener, exporter) =>
+      // Job without spark.sql.execution.id — should be child of app
+      listener.onJobStart(makeJobStart(0, Seq(0)))
+      listener.onJobEnd(makeJobEnd(0, succeeded = true))
+      listener.shutdown()
+
+      val spans = exporter.getFinishedSpanItems.asScala
+      val appSpan = spans.find(_.getName == "spark.application").get
+      val jobSpan = spans.find(_.getName == "spark.job.0").get
+
+      assertEquals(jobSpan.getParentSpanId, appSpan.getSpanId)
+    }
+  }
+
   test("concurrent jobs do not interfere with stage attribution") {
     withListener { (listener, exporter) =>
       // Three concurrent jobs with interleaved stage submissions
@@ -262,6 +418,9 @@ class TracingSparkListenerTest extends FunSuite {
       // Job 2 stages
       assertEquals(stg300.getParentSpanId, job2.getSpanId)
       assertEquals(stg301.getParentSpanId, job2.getSpanId)
+
+      // Clean up
+      SubmitMissingTasksAdviceHelper.jobSpans.clear()
     }
   }
 }


### PR DESCRIPTION
Closes #26

## Summary

- Hook `DAGScheduler.submitMissingTasks(stage, jobId)` via ByteBuddy to inject per-stage W3C traceparent into `ActiveJob.properties` before tasks are created
- Executor task spans now nest under their specific stage span: `app → sql → job → stage → task`
- Captures ALL stages including AQE sub-jobs that bypass `SparkContext.runJob`
- SQL-triggered jobs are parented under their SQL execution span via `spark.sql.execution.id` property lookup
- Race condition between async listener bus and synchronous advice resolved via `putIfAbsent` on shared `ConcurrentHashMap`
- Backward compatible with SparkPlugin-only mode (no ByteBuddy)

## Files

**New:**
- `SubmitMissingTasksInstrumentation.java` — `TypeInstrumentation` targeting `DAGScheduler`
- `SubmitMissingTasksAdvice.java` — `@Advice` enter delegation
- `SubmitMissingTasksAdviceHelper.scala` — span creation, reflection, adoption methods, shared SQL span registry
- `SubmitMissingTasksAdviceHelperTest.scala` — 9 unit tests

**Modified:**
- `SparkContextInstrumentationModule.java` — register `SubmitMissingTasksInstrumentation`
- `TracingSparkListener.scala` — token-based span adoption, SQL→job parenting, shared SQL map
- `FlareDriverState.scala` — widen `applicationSpan` to `private[spark]`
- `LocalPropertyPropagator.scala` — add `injectIntoProperties` for `java.util.Properties`
- `TracingSparkListenerTest.scala` — 8 new tests (adoption, fallback, SQL parenting, concurrent jobs)
- `README.md` — update hierarchy diagram and architecture section

## Verified

- 63/63 tests pass
- Docker e2e: 613 spans, 1 root, zero orphans
- Hierarchy: `app → sql.0 (3 jobs) → job → stage → 200 tasks`, `sql.1 (1 job) → job → stage → 200 tasks`