### PR TITLE
OTEL metrics instruments + Mimir backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **OTEL metrics instruments** — task-level `DoubleHistogram` for duration and throughput,
+  `LongCounter` for shuffle bytes, recorded in `FlareExecutorPlugin.endTask()` with automatic
+  exemplar linking (metrics recorded while span scope is active). Stage-level counters and
+  histograms recorded in `TracingSparkListener.onStageCompleted()` for executor run time,
+  input/output bytes, and shuffle bytes ([#10], [#11])
+- **`FLARE_METRICS_ENABLED`** — kill switch for OTEL metrics emission (default `true`).
+  When disabled, all instruments use a no-op meter with zero overhead
+- **`FlareMetrics`** — centralized holder for all OTEL metric instruments, constructed from
+  a `Meter` instance for testability. Factory method `FlareMetrics.create(enabled)` selects
+  real vs no-op meter
+- **`MetricAttributes`** — helper for building `Attributes` with correct Scala→Java Long
+  boxing for metric dimensional tags (`executor.id`, `stage.id`, `task.result`, `stage.name`)
 - **Per-stage traceparent injection** — `SubmitMissingTasksInstrumentation` hooks
   `DAGScheduler.submitMissingTasks(stage, jobId)` via ByteBuddy to inject a per-stage
   traceparent into `ActiveJob.properties` before tasks are created. Executor task spans now
@@ -110,4 +122,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#9]: https://github.com/Neutrinic/flare/issues/9
 [#14]: https://github.com/Neutrinic/flare/issues/14
 [#15]: https://github.com/Neutrinic/flare/issues/15
+[#10]: https://github.com/Neutrinic/flare/issues/10
+[#11]: https://github.com/Neutrinic/flare/issues/11
 [#26]: https://github.com/Neutrinic/flare/issues/26

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,6 @@ docker/            Docker Compose stack, Spark config, Alloy/Tempo/Loki/Grafana 
 - [ ] `sbt assembly` produces a clean JAR
 - [ ] `sbt ++2.12.18 compile` cross-compiles
 - [ ] No new runtime dependencies added (see below)
-- [ ] New configuration documented in README or CLAUDE.md
 
 ### Dependency policy
 
@@ -137,8 +136,6 @@ wrapping. See `FlareConfig.scala` for the full list. New config variables must:
 
 - Have a sensible default
 - Be validated at startup (fail fast with `IllegalArgumentException`)
-- Be documented in CLAUDE.md
-
 ## License
 
 By contributing, you agree that your contributions will be licensed under the project's

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Neutrinic
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -3,21 +3,21 @@
 OpenTelemetry distributed tracing for Apache Spark — driver-to-executor context propagation.
 
 ```
-spark.application                                    (driver)
-├── spark.sql.0                                      (driver)
-│   ├── spark.job.0                                  (driver)
-│   │   └── spark.stage.0                            (driver)
-│   │       ├── spark.task.executor  (executor-1)    ← Flare
-│   │       └── spark.task.executor  (executor-2)    ← Flare
-│   └── spark.job.1                                  (driver)
-│       └── spark.stage.2                            (driver)
-│           ├── spark.task.executor  (executor-1)    ← Flare
-│           └── spark.task.executor  (executor-2)    ← Flare
-└── spark.sql.1                                      (driver)
-    └── spark.job.2                                  (driver)
-        └── spark.stage.4                            (driver)
-            ├── spark.task.executor  (executor-1)    ← Flare
-            └── spark.task.executor  (executor-2)    ← Flare
+spark.application                          (flare-driver)
+├── spark.sql.0                            (flare-driver)
+│   ├── spark.job.0                        (flare-driver)
+│   │   └── spark.stage.0                  (flare-driver)
+│   │       ├── spark.task.executor        (flare-executor)
+│   │       └── spark.task.executor        (flare-executor)
+│   └── spark.job.1                        (flare-driver)
+│       └── spark.stage.2                  (flare-driver)
+│           ├── spark.task.executor        (flare-executor)
+│           └── spark.task.executor        (flare-executor)
+└── spark.sql.1                            (flare-driver)
+    └── spark.job.2                        (flare-driver)
+        └── spark.stage.4                  (flare-driver)
+            ├── spark.task.executor        (flare-executor)
+            └── spark.task.executor        (flare-executor)
 ```
 
 ## Overview
@@ -70,6 +70,7 @@ Both JARs must be accessible on every node. On Kubernetes, bake them into your S
 | `FLARE_SLOW_TASK_MS` | `0` (disabled) | Only emit task spans exceeding this ms |
 | `FLARE_RETRY_TASKS_ONLY` | `false` | Only emit spans for retries and speculative tasks |
 | `FLARE_MAX_SPANS_PER_TRACE` | `10000` | Circuit breaker for high-cardinality jobs |
+| `FLARE_METRICS_ENABLED` | `true` | Enable OTEL metrics (task duration, shuffle bytes, stage aggregates) |
 | `FLARE_ENABLED` | `true` | Kill switch |
 
 Set via `-DFLARE_*` in `extraJavaOptions` or as environment variables.

--- a/docker/alloy-config.alloy
+++ b/docker/alloy-config.alloy
@@ -1,4 +1,5 @@
-// Grafana Alloy configuration — OTLP receiver forwarding traces to Tempo, logs to Loki
+// Grafana Alloy configuration — OTLP receiver forwarding traces to Tempo,
+// metrics to Mimir, logs to Loki
 
 otelcol.receiver.otlp "default" {
   grpc {
@@ -9,14 +10,26 @@ otelcol.receiver.otlp "default" {
   }
 
   output {
-    traces = [otelcol.exporter.otlp.tempo.input]
-    logs   = [otelcol.exporter.otlphttp.loki.input]
+    traces  = [otelcol.exporter.otlp.tempo.input]
+    metrics = [otelcol.exporter.otlphttp.mimir.input]
+    logs    = [otelcol.exporter.otlphttp.loki.input]
   }
 }
 
 otelcol.exporter.otlp "tempo" {
   client {
     endpoint = "tempo:4317"
+
+    tls {
+      insecure = true
+    }
+  }
+}
+
+// OTLP metrics → Mimir via OTLP HTTP (Mimir supports native OTLP ingestion)
+otelcol.exporter.otlphttp "mimir" {
+  client {
+    endpoint = "http://mimir:9009/otlp"
 
     tls {
       insecure = true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - SPARK_ROLE=master
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317
       - OTEL_RESOURCE_ATTRIBUTES=cluster.name=flare-dev,environment=development
+      - OTEL_METRIC_EXPORT_INTERVAL=10000
       - FLARE_TRACE_GRANULARITY=all
       - FLARE_SAMPLING_RATIO=1.0
     ports:
@@ -41,6 +42,7 @@ services:
       - SPARK_MASTER_URL=spark://spark-master:7077
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317
       - OTEL_RESOURCE_ATTRIBUTES=cluster.name=flare-dev,environment=development
+      - OTEL_METRIC_EXPORT_INTERVAL=10000
       - FLARE_TRACE_GRANULARITY=all
       - FLARE_SAMPLING_RATIO=1.0
     ports:
@@ -63,6 +65,7 @@ services:
       - SPARK_MASTER_URL=spark://spark-master:7077
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317
       - OTEL_RESOURCE_ATTRIBUTES=cluster.name=flare-dev,environment=development
+      - OTEL_METRIC_EXPORT_INTERVAL=10000
       - FLARE_TRACE_GRANULARITY=all
       - FLARE_SAMPLING_RATIO=1.0
     ports:
@@ -115,6 +118,17 @@ services:
     command: -config.file=/etc/loki/config.yaml
     networks: [flare-net]
 
+  mimir:
+    image: grafana/mimir:2.15.0
+    hostname: mimir
+    ports:
+      - "9009:9009"   # Mimir HTTP (Prometheus-compatible query + OTLP ingest)
+    volumes:
+      - ./mimir-config.yaml:/etc/mimir/config.yaml:ro
+      - mimir-data:/data/mimir
+    command: -config.file=/etc/mimir/config.yaml
+    networks: [flare-net]
+
   tempo:
     image: grafana/tempo:2.6.1
     hostname: tempo
@@ -139,7 +153,7 @@ services:
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - grafana-data:/var/lib/grafana
-    depends_on: [tempo, loki]
+    depends_on: [tempo, mimir, loki]
     networks: [flare-net]
 
 networks:
@@ -150,5 +164,6 @@ volumes:
   spark-events:
   spark-logs:
   loki-data:
+  mimir-data:
   tempo-data:
   grafana-data:

--- a/docker/grafana/provisioning/datasources/tempo.yaml
+++ b/docker/grafana/provisioning/datasources/tempo.yaml
@@ -13,13 +13,46 @@ datasources:
       tracesToLogsV2:
         datasourceUid: loki
         filterByTraceID: true
-        filterBySpanID: true
+        filterBySpanID: false
       tracesToMetrics:
-        datasourceUid: ''
+        datasourceUid: mimir
+        spanStartTimeShift: '-30m'
+        spanEndTimeShift: '30m'
+        queries:
+          - name: Task Duration p95 (ms)
+            query: 'histogram_quantile(0.95, sum(spark_task_duration_bucket) by (le))'
+          - name: Avg Task Duration (ms)
+            query: 'sum(spark_task_duration_sum) / sum(spark_task_duration_count)'
+          - name: Total Tasks
+            query: 'sum(spark_task_duration_count)'
+          - name: Shuffle Read (bytes)
+            query: 'sum(spark_task_shuffle_read_bytes)'
+          - name: Shuffle Write (bytes)
+            query: 'sum(spark_task_shuffle_write_bytes)'
+          - name: Stage Executor Run Time p95 (ms)
+            query: 'histogram_quantile(0.95, sum(spark_stage_executor_run_time_bucket) by (le))'
+          - name: Stage Input (bytes)
+            query: 'sum(spark_stage_input_bytes)'
+          - name: Stage Shuffle Read (bytes)
+            query: 'sum(spark_stage_shuffle_read_bytes)'
+          - name: Stage Shuffle Write (bytes)
+            query: 'sum(spark_stage_shuffle_write_bytes)'
       nodeGraph:
         enabled: true
       serviceMap:
-        datasourceUid: ''
+        datasourceUid: mimir
+
+  - name: Mimir
+    type: prometheus
+    access: proxy
+    uid: mimir
+    url: http://mimir:9009/prometheus
+    editable: false
+    jsonData:
+      httpMethod: POST
+      exemplarTraceIdDestinations:
+        - name: trace_id
+          datasourceUid: tempo
 
   - name: Loki
     type: loki

--- a/docker/loki-config.yaml
+++ b/docker/loki-config.yaml
@@ -27,3 +27,10 @@ schema_config:
 limits_config:
   # Accept OTLP structured metadata (trace_id, span_id) for log-to-trace correlation
   allow_structured_metadata: true
+  otlp_config:
+    # Demote noisy resource attributes to structured metadata to reduce label cardinality.
+    # Defaults (service_name, etc.) remain as index labels.
+    resource_attributes:
+      attributes_config:
+        - action: structured_metadata
+          regex: '^(process_.*|telemetry_.*|os_.*|host_.*|container_id|observed_timestamp|service_instance_id)$'

--- a/docker/mimir-config.yaml
+++ b/docker/mimir-config.yaml
@@ -1,0 +1,46 @@
+# Mimir single-binary mode — OTLP metrics ingest for dev stack
+
+target: all
+
+multitenancy_enabled: false
+
+server:
+  http_listen_port: 9009
+  grpc_listen_port: 9095
+
+distributor:
+  ring:
+    kvstore:
+      store: inmemory
+    instance_addr: 127.0.0.1
+
+ingester:
+  ring:
+    kvstore:
+      store: inmemory
+    instance_addr: 127.0.0.1
+    replication_factor: 1
+
+blocks_storage:
+  backend: filesystem
+  filesystem:
+    dir: /data/mimir/blocks
+  tsdb:
+    dir: /data/mimir/tsdb
+  bucket_store:
+    sync_dir: /data/mimir/sync
+
+compactor:
+  data_dir: /data/mimir/compactor
+  sharding_ring:
+    kvstore:
+      store: inmemory
+
+store_gateway:
+  sharding_ring:
+    kvstore:
+      store: inmemory
+    replication_factor: 1
+
+limits:
+  native_histograms_ingestion_enabled: true

--- a/docker/tempo-config.yaml
+++ b/docker/tempo-config.yaml
@@ -22,11 +22,16 @@ metrics_generator:
       store: inmemory
   processor:
     service_graphs:
+      max_items: 10000
     span_metrics:
-    local_blocks:
+      dimensions:
+        - service.name
+      enable_target_info: true
   storage:
     path: /var/tempo/generator/wal
-    remote_write: []
+    remote_write:
+      - url: http://mimir:9009/api/v1/push
+        send_exemplars: true
 
 overrides:
   defaults:
@@ -34,7 +39,6 @@ overrides:
       processors:
         - service-graphs
         - span-metrics
-        - local-blocks
 
 storage:
   trace:

--- a/src/main/scala/io/flare/spark/config/FlareConfig.scala
+++ b/src/main/scala/io/flare/spark/config/FlareConfig.scala
@@ -31,6 +31,7 @@ final case class FlareConfig(
   // None = no filter. Some(r) = only stages whose name matches r get task spans.
   // Compiled once at load time, not per task.
   taskStagePattern: Option[Regex],
+  metricsEnabled:   Boolean,      // FLARE_METRICS_ENABLED, default true
 ) {
   def tracesJobs:        Boolean = enabled
   def tracesStages:      Boolean = enabled && granularity != TraceGranularity.Jobs
@@ -153,6 +154,9 @@ object FlareConfig {
         }
       }
 
+    val metricsEnabled = !envOrProp("FLARE_METRICS_ENABLED")
+      .map(_.toLowerCase).contains("false")
+
     FlareConfig(
       enabled          = enabled,
       granularity      = granularity,
@@ -162,6 +166,7 @@ object FlareConfig {
       retryTasksOnly   = retryTasksOnly,
       taskStageIds     = taskStageIds,
       taskStagePattern = taskStagePattern,
+      metricsEnabled   = metricsEnabled,
     )
   }
 }

--- a/src/main/scala/io/flare/spark/instrumentation/SparkContextAdviceHelper.scala
+++ b/src/main/scala/io/flare/spark/instrumentation/SparkContextAdviceHelper.scala
@@ -4,6 +4,7 @@ import io.flare.spark.BuildInfo
 import io.flare.spark.attributes.SparkAttributes._
 import io.flare.spark.config.FlareConfig
 import io.flare.spark.listener.TracingSparkListener
+import io.flare.spark.metrics.FlareMetrics
 import io.flare.spark.plugin.FlareDriverState
 import io.flare.spark.propagation.LocalPropertyPropagator
 import io.opentelemetry.api.GlobalOpenTelemetry
@@ -63,7 +64,8 @@ object SparkContextAdviceHelper {
       LocalPropertyPropagator.inject(spanContext, sc)
 
       // 3. Create listener (but do NOT register with SparkContext yet)
-      val tracingListener = new TracingSparkListener(tracer, config)
+      val flareMetrics = FlareMetrics.create(config.metricsEnabled)
+      val tracingListener = new TracingSparkListener(tracer, config, Some(flareMetrics))
       tracingListener.setApplicationSpan(appSpan)
 
       // 4. Atomically register in shared state — must happen BEFORE addSparkListener.

--- a/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
+++ b/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
@@ -4,6 +4,7 @@ import io.flare.spark.SpanCompat._
 import io.flare.spark.attributes.SparkAttributes._
 import io.flare.spark.config.FlareConfig
 import io.flare.spark.instrumentation.SubmitMissingTasksAdviceHelper
+import io.flare.spark.metrics.{FlareMetrics, MetricAttributes}
 import io.opentelemetry.api.trace.{Span, SpanKind, StatusCode, Tracer}
 import io.opentelemetry.context.Context
 import org.apache.spark.scheduler._
@@ -28,6 +29,7 @@ import scala.collection.concurrent.TrieMap
 class TracingSparkListener(
   tracer:  Tracer,
   config:  FlareConfig,
+  metrics: Option[FlareMetrics] = None,
   // When true, safeHandle rethrows exceptions instead of swallowing them.
   // Set to true in tests so assertion failures surface the actual cause.
   private val throwOnError: Boolean = false,
@@ -205,6 +207,20 @@ class TracingSparkListener(
           span.setLong(Stage.ShuffleReadBytes, m.shuffleReadMetrics.totalBytesRead)
           span.setLong(Stage.ShuffleWriteBytes, m.shuffleWriteMetrics.bytesWritten)
           span.setLong(Stage.MemorySpilled, m.memoryBytesSpilled)
+
+          // Record OTEL stage-level metrics
+          metrics.foreach { fm =>
+            val attrs = MetricAttributes.forStage(stageId, event.stageInfo.name)
+            fm.stageExecutorRunTime.record(m.executorRunTime.toDouble, attrs)
+            val inputBytes = m.inputMetrics.bytesRead
+            if (inputBytes > 0) fm.stageInputBytes.add(inputBytes, attrs)
+            val outputBytes = m.outputMetrics.bytesWritten
+            if (outputBytes > 0) fm.stageOutputBytes.add(outputBytes, attrs)
+            val shuffleRead = m.shuffleReadMetrics.totalBytesRead
+            if (shuffleRead > 0) fm.stageShuffleReadBytes.add(shuffleRead, attrs)
+            val shuffleWrite = m.shuffleWriteMetrics.bytesWritten
+            if (shuffleWrite > 0) fm.stageShuffleWriteBytes.add(shuffleWrite, attrs)
+          }
         }
 
         event.stageInfo.failureReason match {

--- a/src/main/scala/io/flare/spark/metrics/FlareMetrics.scala
+++ b/src/main/scala/io/flare/spark/metrics/FlareMetrics.scala
@@ -1,0 +1,92 @@
+package io.flare.spark.metrics
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.metrics.{DoubleHistogram, LongCounter, Meter}
+
+/**
+ * Holder for all Flare OTEL metric instruments.
+ *
+ * Constructed from a `Meter` instance — production code uses `GlobalOpenTelemetry.getMeter()`,
+ * tests can pass a meter backed by `InMemoryMetricReader`.
+ *
+ * When metrics are disabled, the meter is a no-op instance so all recording calls
+ * are zero-cost no-ops without per-call `if` checks.
+ *
+ * Instruments are thread-safe by OTEL contract.
+ */
+class FlareMetrics(meter: Meter) {
+
+  // ── Executor-side (Issue #11) ──────────────────────────────────────────
+
+  val taskDuration: DoubleHistogram = meter
+    .histogramBuilder("spark.task.duration")
+    .setDescription("Task execution duration")
+    .setUnit("ms")
+    .build()
+
+  val taskRecordsThroughput: DoubleHistogram = meter
+    .histogramBuilder("spark.task.records_throughput")
+    .setDescription("Task records processed per second")
+    .setUnit("{records}/s")
+    .build()
+
+  val taskShuffleReadBytes: LongCounter = meter
+    .counterBuilder("spark.task.shuffle.read_bytes")
+    .setDescription("Bytes read during shuffle by individual tasks")
+    .setUnit("By")
+    .build()
+
+  val taskShuffleWriteBytes: LongCounter = meter
+    .counterBuilder("spark.task.shuffle.write_bytes")
+    .setDescription("Bytes written during shuffle by individual tasks")
+    .setUnit("By")
+    .build()
+
+  // ── Driver-side (Issue #10 partial) ────────────────────────────────────
+
+  val stageExecutorRunTime: DoubleHistogram = meter
+    .histogramBuilder("spark.stage.executor.run_time")
+    .setDescription("Total executor run time per stage")
+    .setUnit("ms")
+    .build()
+
+  val stageInputBytes: LongCounter = meter
+    .counterBuilder("spark.stage.input.bytes")
+    .setDescription("Total bytes read across all tasks in a stage")
+    .setUnit("By")
+    .build()
+
+  val stageOutputBytes: LongCounter = meter
+    .counterBuilder("spark.stage.output.bytes")
+    .setDescription("Total bytes written across all tasks in a stage")
+    .setUnit("By")
+    .build()
+
+  val stageShuffleReadBytes: LongCounter = meter
+    .counterBuilder("spark.stage.shuffle.read_bytes")
+    .setDescription("Total shuffle bytes read in a stage")
+    .setUnit("By")
+    .build()
+
+  val stageShuffleWriteBytes: LongCounter = meter
+    .counterBuilder("spark.stage.shuffle.write_bytes")
+    .setDescription("Total shuffle bytes written in a stage")
+    .setUnit("By")
+    .build()
+}
+
+object FlareMetrics {
+
+  /**
+   * Create a `FlareMetrics` instance. When `enabled` is false, returns an instance
+   * backed by a no-op meter so all recording calls silently discard data.
+   */
+  def create(enabled: Boolean): FlareMetrics = {
+    val meter = if (enabled)
+      GlobalOpenTelemetry.getMeter("io.flare.spark")
+    else
+      OpenTelemetry.noop().getMeter("io.flare.spark")
+    new FlareMetrics(meter)
+  }
+}

--- a/src/main/scala/io/flare/spark/metrics/MetricAttributes.scala
+++ b/src/main/scala/io/flare/spark/metrics/MetricAttributes.scala
@@ -1,0 +1,29 @@
+package io.flare.spark.metrics
+
+import io.opentelemetry.api.common.{AttributeKey, Attributes}
+
+/**
+ * Helpers for building OTEL `Attributes` used as metric dimensional tags.
+ *
+ * Uses `Attributes.builder()` instead of `Attributes.of()` to avoid
+ * Scala-Java boxing ambiguity with `AttributeKey[Long]`.
+ */
+object MetricAttributes {
+
+  private val ExecutorId = AttributeKey.stringKey("executor.id")
+  private val StageName  = AttributeKey.stringKey("stage.name")
+  private val Result     = AttributeKey.stringKey("task.result")
+
+  def forTask(executorId: String, stageId: Int, result: String): Attributes =
+    Attributes.builder()
+      .put(ExecutorId, executorId)
+      .put("stage.id", stageId.toLong)
+      .put(Result, result)
+      .build()
+
+  def forStage(stageId: Int, stageName: String): Attributes =
+    Attributes.builder()
+      .put("stage.id", stageId.toLong)
+      .put(StageName, stageName)
+      .build()
+}

--- a/src/main/scala/io/flare/spark/plugin/FlareDriverPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareDriverPlugin.scala
@@ -4,6 +4,7 @@ import io.flare.spark.BuildInfo
 import io.flare.spark.attributes.SparkAttributes._
 import io.flare.spark.config.FlareConfig
 import io.flare.spark.listener.TracingSparkListener
+import io.flare.spark.metrics.FlareMetrics
 import io.flare.spark.propagation.LocalPropertyPropagator
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.{Span, SpanKind, StatusCode}
@@ -80,7 +81,8 @@ class FlareDriverPlugin extends DriverPlugin {
     LocalPropertyPropagator.inject(spanContext, sc)
 
     // 3. Register TracingSparkListener for driver-side job/stage/SQL spans
-    val tracingListener = new TracingSparkListener(tracer, config)
+    val flareMetrics = FlareMetrics.create(config.metricsEnabled)
+    val tracingListener = new TracingSparkListener(tracer, config, Some(flareMetrics))
     tracingListener.setApplicationSpan(appSpan)
     sc.addSparkListener(tracingListener)
     listener = Some(tracingListener)
@@ -110,6 +112,22 @@ class FlareDriverPlugin extends DriverPlugin {
         span.setStatus(StatusCode.OK)
         span.end()
       }
+    }
+
+    // Force-flush TracerProvider and MeterProvider to push buffered spans/metrics.
+    try {
+      GlobalOpenTelemetry.get() match {
+        case sdk: io.opentelemetry.sdk.OpenTelemetrySdk =>
+          sdk.getSdkTracerProvider.forceFlush().join(5, ju.concurrent.TimeUnit.SECONDS)
+          sdk.getSdkMeterProvider.forceFlush().join(5, ju.concurrent.TimeUnit.SECONDS)
+          logger.info("[Flare] Forced flush of TracerProvider and MeterProvider completed")
+        case _ => ()
+      }
+    } catch {
+      case _: NoClassDefFoundError =>
+        logger.debug("[Flare] SDK classes not accessible, relying on agent shutdown hook")
+      case e: Exception =>
+        logger.warn(s"[Flare] Error during shutdown flush: {}", e.getMessage)
     }
 
     logger.info("[Flare] Driver plugin shutdown complete")

--- a/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
@@ -4,6 +4,7 @@ import io.flare.spark.BuildInfo
 import io.flare.spark.SpanCompat._
 import io.flare.spark.attributes.SparkAttributes._
 import io.flare.spark.config.{FlareConfig, TraceGranularity}
+import io.flare.spark.metrics.{FlareMetrics, MetricAttributes}
 import io.flare.spark.propagation.LocalPropertyPropagator
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.{Span, SpanKind, StatusCode}
@@ -35,6 +36,8 @@ class FlareExecutorPlugin extends ExecutorPlugin {
   // Loaded once in init(), then only read — no volatile needed since Spark guarantees
   // init() completes before any task callbacks fire on this executor.
   private var config: FlareConfig = _
+  private var metrics: FlareMetrics = _
+  private var executorId: String = "unknown"
 
   // Counts spans created on this executor JVM across all tasks.
   private val spanCount = new AtomicLong(0L)
@@ -57,11 +60,14 @@ class FlareExecutorPlugin extends ExecutorPlugin {
         logger.error(s"[Flare] Configuration error — executor task spans disabled: ${e.getMessage}")
         FlareConfig(enabled = false, granularity = TraceGranularity.Stages,
           samplingRatio = 0.0, maxSpansPerTrace = 0, slowTaskMs = 0L,
-          retryTasksOnly = false, taskStageIds = Set.empty, taskStagePattern = None)
+          retryTasksOnly = false, taskStageIds = Set.empty, taskStagePattern = None,
+          metricsEnabled = false)
     }
-    logger.info(s"[Flare] Executor plugin initialized (granularity=${config.granularity}, " +
+    metrics = FlareMetrics.create(config.metricsEnabled)
+    executorId = ctx.executorID()
+    logger.info(s"[Flare] Executor plugin initialized (executorId=$executorId, granularity=${config.granularity}, " +
       s"sampling=${config.samplingRatio}, maxSpans=${config.maxSpansPerTrace}, " +
-      s"taskTracing=${config.tracesTasks})")
+      s"taskTracing=${config.tracesTasks}, metrics=${config.metricsEnabled})")
 
     // Stage name is not available on the executor in Phase 1 (ExecutorPlugin has no access to
     // stage metadata — only stageId from TaskContext). Warn if someone configures the pattern
@@ -168,6 +174,9 @@ class FlareExecutorPlugin extends ExecutorPlugin {
         // pressure proportional to concurrent executor threads, not total tasks — each ThreadLocal
         // is overwritten on the next task. Acceptable for the filtering benefit.
         if (config.slowTaskMs > 0 && durationMs >= 0 && durationMs < config.slowTaskMs) {
+          // Record metrics even for fast tasks whose spans are dropped — metrics have
+          // their own aggregation and don't suffer from span cardinality pressure.
+          recordTaskMetrics(capturedTaskContext, durationMs, success)
           MdcEnricher.remove()
           scope.close()
           spanCount.decrementAndGet() // reclaim slot — this span won't be exported
@@ -212,6 +221,10 @@ class FlareExecutorPlugin extends ExecutorPlugin {
         Option(capturedTaskContext.getLocalProperty("spark.sql.execution.id"))
           .flatMap(_.toLongOption)
           .foreach(id => span.setLong(Task.SqlExecutionId, id))
+
+        // Record OTEL metrics while span scope is still active → automatic exemplar linking.
+        // The SDK captures the current span's trace ID + span ID on each data point.
+        recordTaskMetrics(capturedTaskContext, durationMs, success)
       } finally {
         MdcEnricher.remove()
         scope.close()
@@ -219,6 +232,33 @@ class FlareExecutorPlugin extends ExecutorPlugin {
         taskState.remove()
         taskStartNanos.remove()
       }
+    }
+  }
+
+  private def recordTaskMetrics(tc: TaskContext, durationMs: Long, success: Boolean): Unit = {
+    try {
+      val eid = this.executorId
+      val attrs = MetricAttributes.forTask(eid, tc.stageId(), if (success) "SUCCESS" else "FAILED")
+
+      if (durationMs >= 0) {
+        metrics.taskDuration.record(durationMs.toDouble, attrs)
+      }
+
+      val m = tc.taskMetrics()
+      val totalRecords = m.inputMetrics.recordsRead + m.outputMetrics.recordsWritten
+      if (durationMs > 0 && totalRecords > 0) {
+        val throughput = totalRecords.toDouble / (durationMs.toDouble / 1000.0)
+        metrics.taskRecordsThroughput.record(throughput, attrs)
+      }
+
+      val shuffleRead = m.shuffleReadMetrics.totalBytesRead
+      if (shuffleRead > 0) metrics.taskShuffleReadBytes.add(shuffleRead, attrs)
+
+      val shuffleWrite = m.shuffleWriteMetrics.bytesWritten
+      if (shuffleWrite > 0) metrics.taskShuffleWriteBytes.add(shuffleWrite, attrs)
+    } catch {
+      case e: Throwable =>
+        logger.debug(s"[Flare] Could not record task metrics: ${e.getClass.getSimpleName}: ${e.getMessage}")
     }
   }
 
@@ -235,14 +275,15 @@ class FlareExecutorPlugin extends ExecutorPlugin {
       taskState.remove()
     }
 
-    // Force-flush TracerProvider to push buffered spans before JVM exits.
-    // The SDK classes live in the agent classloader — catch NoClassDefFoundError
-    // if they're not visible from the app classloader.
+    // Force-flush TracerProvider and MeterProvider to push buffered spans/metrics
+    // before JVM exits. The SDK classes live in the agent classloader — catch
+    // NoClassDefFoundError if they're not visible from the app classloader.
     try {
       GlobalOpenTelemetry.get() match {
         case sdk: io.opentelemetry.sdk.OpenTelemetrySdk =>
           sdk.getSdkTracerProvider.forceFlush().join(5, ju.concurrent.TimeUnit.SECONDS)
-          logger.info("[Flare] Forced flush of TracerProvider completed")
+          sdk.getSdkMeterProvider.forceFlush().join(5, ju.concurrent.TimeUnit.SECONDS)
+          logger.info("[Flare] Forced flush of TracerProvider and MeterProvider completed")
         case _ => ()
       }
     } catch {

--- a/src/test/scala/io/flare/spark/config/FlareConfigTest.scala
+++ b/src/test/scala/io/flare/spark/config/FlareConfigTest.scala
@@ -22,6 +22,7 @@ class FlareConfigTest extends FunSuite {
       retryTasksOnly   = retryTasksOnly,
       taskStageIds     = taskStageIds,
       taskStagePattern = taskStagePattern,
+      metricsEnabled   = true,
     )
 
   // ── shouldTraceTask tests ──────────────────────────────────────────────────
@@ -134,7 +135,7 @@ class FlareConfigTest extends FunSuite {
   private val testProps = List(
     "FLARE_ENABLED", "FLARE_TRACE_GRANULARITY", "FLARE_SAMPLING_RATIO",
     "FLARE_MAX_SPANS_PER_TRACE", "FLARE_SLOW_TASK_MS", "FLARE_RETRY_TASKS_ONLY",
-    "FLARE_TASK_STAGES", "FLARE_TASK_STAGE_PATTERN",
+    "FLARE_TASK_STAGES", "FLARE_TASK_STAGE_PATTERN", "FLARE_METRICS_ENABLED",
   )
 
   override def afterEach(context: AfterEach): Unit = {
@@ -200,5 +201,17 @@ class FlareConfigTest extends FunSuite {
     assert(!config.retryTasksOnly)
     assert(config.taskStageIds.isEmpty)
     assert(config.taskStagePattern.isEmpty)
+    assert(config.metricsEnabled)
+  }
+
+  test("load() FLARE_METRICS_ENABLED=false disables metrics") {
+    sys.props("FLARE_METRICS_ENABLED") = "false"
+    val config = FlareConfig.load()
+    assert(!config.metricsEnabled)
+  }
+
+  test("load() FLARE_METRICS_ENABLED defaults to true") {
+    val config = FlareConfig.load()
+    assert(config.metricsEnabled)
   }
 }

--- a/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
+++ b/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
@@ -25,6 +25,7 @@ class TracingSparkListenerTest extends FunSuite {
     retryTasksOnly   = false,
     taskStageIds     = Set.empty,
     taskStagePattern = None,
+    metricsEnabled   = true,
   )
 
   /**

--- a/src/test/scala/io/flare/spark/metrics/FlareMetricsTest.scala
+++ b/src/test/scala/io/flare/spark/metrics/FlareMetricsTest.scala
@@ -1,0 +1,110 @@
+package io.flare.spark.metrics
+
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
+import munit.FunSuite
+
+import scala.jdk.CollectionConverters._
+
+class FlareMetricsTest extends FunSuite {
+
+  private def withMetrics(body: (FlareMetrics, InMemoryMetricReader) => Unit): Unit = {
+    val reader = InMemoryMetricReader.create()
+    val meterProvider = SdkMeterProvider.builder()
+      .registerMetricReader(reader)
+      .build()
+    val meter = meterProvider.get("io.flare.spark")
+    val metrics = new FlareMetrics(meter)
+    try body(metrics, reader)
+    finally meterProvider.close()
+  }
+
+  test("taskDuration histogram records a value") {
+    withMetrics { (metrics, reader) =>
+      val attrs = MetricAttributes.forTask("exec-0", 3, "SUCCESS")
+      metrics.taskDuration.record(150.0, attrs)
+
+      val metricData = reader.collectAllMetrics().asScala
+      val histogram = metricData.find(_.getName == "spark.task.duration")
+      assert(histogram.isDefined, s"Expected spark.task.duration, got: ${metricData.map(_.getName).mkString(", ")}")
+    }
+  }
+
+  test("taskRecordsThroughput histogram records a value") {
+    withMetrics { (metrics, reader) =>
+      val attrs = MetricAttributes.forTask("exec-0", 1, "SUCCESS")
+      metrics.taskRecordsThroughput.record(5000.0, attrs)
+
+      val metricData = reader.collectAllMetrics().asScala
+      val histogram = metricData.find(_.getName == "spark.task.records_throughput")
+      assert(histogram.isDefined)
+    }
+  }
+
+  test("taskShuffleReadBytes counter increments") {
+    withMetrics { (metrics, reader) =>
+      val attrs = MetricAttributes.forTask("exec-1", 5, "SUCCESS")
+      metrics.taskShuffleReadBytes.add(1024L, attrs)
+      metrics.taskShuffleReadBytes.add(2048L, attrs)
+
+      val metricData = reader.collectAllMetrics().asScala
+      val counter = metricData.find(_.getName == "spark.task.shuffle.read_bytes")
+      assert(counter.isDefined, s"Expected spark.task.shuffle.read_bytes, got: ${metricData.map(_.getName).mkString(", ")}")
+    }
+  }
+
+  test("stage metrics record correctly") {
+    withMetrics { (metrics, reader) =>
+      val attrs = MetricAttributes.forStage(7, "shuffle read")
+      metrics.stageExecutorRunTime.record(3500.0, attrs)
+      metrics.stageInputBytes.add(1048576L, attrs)
+      metrics.stageShuffleReadBytes.add(512000L, attrs)
+
+      val metricData = reader.collectAllMetrics().asScala
+      val names = metricData.map(_.getName).toSet
+      assert(names.contains("spark.stage.executor.run_time"))
+      assert(names.contains("spark.stage.input.bytes"))
+      assert(names.contains("spark.stage.shuffle.read_bytes"))
+    }
+  }
+
+  test("noop metrics discard all recordings") {
+    val noopMeter = OpenTelemetry.noop().getMeter("io.flare.spark")
+    val metrics = new FlareMetrics(noopMeter)
+
+    // These should not throw — no-op instruments silently discard
+    val attrs = MetricAttributes.forTask("exec-0", 1, "SUCCESS")
+    metrics.taskDuration.record(100.0, attrs)
+    metrics.taskShuffleReadBytes.add(1024L, attrs)
+    metrics.taskRecordsThroughput.record(5000.0, attrs)
+  }
+
+  test("FlareMetrics.create(enabled=false) returns noop instance") {
+    // When disabled, instruments are backed by no-op meter.
+    // Just verify it doesn't throw.
+    val metrics = FlareMetrics.create(enabled = false)
+    val attrs = MetricAttributes.forTask("exec-0", 1, "SUCCESS")
+    metrics.taskDuration.record(100.0, attrs)
+  }
+
+  test("MetricAttributes.forTask includes correct keys") {
+    val attrs = MetricAttributes.forTask("exec-2", 10, "FAILED")
+    val attrMap = new java.util.HashMap[String, Any]()
+    attrs.forEach((k, v) => attrMap.put(k.getKey, v))
+
+    assertEquals(attrMap.get("executor.id"), "exec-2")
+    assertEquals(attrMap.get("stage.id"), 10L: java.lang.Long)
+    assertEquals(attrMap.get("task.result"), "FAILED")
+  }
+
+  test("MetricAttributes.forStage includes correct keys") {
+    val attrs = MetricAttributes.forStage(7, "shuffle read")
+    val attrMap = new java.util.HashMap[String, Any]()
+    attrs.forEach((k, v) => attrMap.put(k.getKey, v))
+
+    assertEquals(attrMap.get("stage.id"), 7L: java.lang.Long)
+    assertEquals(attrMap.get("stage.name"), "shuffle read")
+  }
+}

--- a/src/test/scala/io/flare/spark/plugin/FlareDriverStateTest.scala
+++ b/src/test/scala/io/flare/spark/plugin/FlareDriverStateTest.scala
@@ -32,6 +32,7 @@ class FlareDriverStateTest extends FunSuite {
     retryTasksOnly   = false,
     taskStageIds     = Set.empty,
     taskStagePattern = None,
+    metricsEnabled   = true,
   )
 
   override def beforeEach(context: BeforeEach): Unit = {


### PR DESCRIPTION
Closes #10
Closes #11

## Summary
- Add task-level OTEL metric instruments (`spark.task.duration` histogram, `spark.task.records_throughput` histogram, `spark.task.shuffle.read_bytes` / `write_bytes` counters) recorded in `FlareExecutorPlugin.endTask()` with automatic exemplar linking
- Add stage-level OTEL metric instruments (`spark.stage.executor.run_time` histogram, `spark.stage.input.bytes` / `output.bytes` / `shuffle.read_bytes` / `shuffle.write_bytes` counters) recorded in `TracingSparkListener.onStageCompleted()`
- Add `FLARE_METRICS_ENABLED` config (default `true`) with zero-cost no-op meter when disabled
- Add Mimir to Docker stack for metrics storage with OTLP ingestion
- Configure Alloy to route OTLP metrics to Mimir, logs to Loki, traces to Tempo
- Configure Tempo span-metrics generator with `remote_write` to Mimir for RED metrics
- Add Grafana `tracesToMetrics` queries linking spans to task/stage metrics in Mimir
- Add Grafana exemplar linking (Mimir metric → Tempo trace)
- Tune Loki OTLP resource attribute cardinality (demote noisy attrs to structured metadata)
- Flush both `TracerProvider` and `MeterProvider` on executor/driver shutdown
- 10-second metric export interval in dev stack for better batch job metric capture

## Test plan
- [x] All 73 unit tests pass (`sbt test`)
- [x] Assembly builds successfully
- [x] Docker e2e: SkewedJob produces correct trace hierarchy with task/stage metrics in Mimir
- [x] Grafana tracesToMetrics panel shows task duration p95, avg duration, total tasks, shuffle bytes, stage metrics when viewing a trace
- [x] Exemplar linking from Mimir metrics to Tempo traces works
- [x] Logs correlation from traces still works (filterBySpanID=false for parent spans)
- [x] Tempo service map and node graph populated via span-metrics generator