### PR TITLE
Cross-publish matrix: Spark 3.3-4.0 x Scala 2.12/2.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,27 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - spark: "3.3.4"
+            scala: "2.12.18"
+          - spark: "3.3.4"
+            scala: "2.13.16"
+          - spark: "3.4.3"
+            scala: "2.12.18"
+          - spark: "3.4.3"
+            scala: "2.13.16"
+          - spark: "3.5.1"
+            scala: "2.12.18"
+          - spark: "3.5.1"
+            scala: "2.13.16"
+          - spark: "4.0.0"
+            scala: "2.13.16"
+
+    name: Spark ${{ matrix.spark }} / Scala ${{ matrix.scala }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -21,10 +42,10 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - name: Compile
-        run: sbt compile
+        run: sbt -DsparkVersion=${{ matrix.spark }} ++${{ matrix.scala }} compile
 
       - name: Test
-        run: sbt test
+        run: sbt -DsparkVersion=${{ matrix.spark }} ++${{ matrix.scala }} test
 
       - name: Assembly
-        run: sbt assembly
+        run: sbt -DsparkVersion=${{ matrix.spark }} ++${{ matrix.scala }} assembly

--- a/README.md
+++ b/README.md
@@ -103,8 +103,24 @@ Requires Java 17+ and sbt.
 
 ```bash
 sbt compile
-sbt assembly  # fat JAR at target/scala-2.13/flare-spark-assembly-*.jar
+sbt assembly  # fat JAR at target/scala-2.13/flare-spark-3.5.jar
 ```
+
+Cross-compile for a specific Spark version:
+
+```bash
+sbt -DsparkVersion=3.3.4 ++2.12.18 assembly   # Spark 3.3, Scala 2.12
+sbt -DsparkVersion=4.0.0 ++2.13.16 assembly   # Spark 4.0, Scala 2.13
+```
+
+Supported matrix:
+
+| Spark | Scala 2.12 | Scala 2.13 |
+|-------|:----------:|:----------:|
+| 3.3   | ✓          | ✓          |
+| 3.4   | ✓          | ✓          |
+| 3.5   | ✓          | ✓          |
+| 4.0   |            | ✓          |
 
 ## Docker
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,23 +14,31 @@ ThisBuild / scalacOptions ++= Seq(
   "-Xlint",
 )
 
-ThisBuild / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-  case Some((2, 12)) => Seq("-Ypartial-unification", "-Ywarn-unused:imports")
-  case Some((2, 13)) => Seq("-Ywarn-unused:imports")
-  case _             => Seq.empty
-})
+// NOTE: version-dependent scalacOptions are in root project settings, not ThisBuild,
+// because `++2.12.18` changes ThisBuild/scalaVersion which would leak -Ypartial-unification
+// to the examples sub-project (which stays on 2.13 and rejects that flag).
 
 // Spark version to build against (override with -DsparkVersion=3.5.1)
 val sparkBuildVersion = sys.props.getOrElse("sparkVersion", spark35)
+val sparkMajorMinor   = sparkBuildVersion.split('.').take(2).mkString(".")
 
 lazy val root = (project in file("."))
   .enablePlugins(BuildInfoPlugin)
   .aggregate(examples)
   .settings(
-    name := "flare-spark",
+    name := s"flare-spark-$sparkMajorMinor",
+
+    // Spark 4.0 dropped Scala 2.12
+    crossScalaVersions := (if (sparkMajorMinor == "4.0") Seq(scala213) else Seq(scala212, scala213)),
+
+    scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 12)) => Seq("-Ypartial-unification", "-Ywarn-unused:imports")
+      case Some((2, 13)) => Seq("-Ywarn-unused:imports")
+      case _             => Seq.empty
+    }),
 
     // sbt-buildinfo — generates io.flare.spark.BuildInfo with version at compile time
-    buildInfoKeys    := Seq[BuildInfoKey](name, version),
+    buildInfoKeys    := Seq[BuildInfoKey](name, version, "sparkVersion" -> sparkBuildVersion),
     buildInfoPackage := "io.flare.spark",
     buildInfoObject  := "BuildInfo",
 
@@ -51,7 +59,7 @@ lazy val root = (project in file("."))
 
     // Bundle OTEL API + context (needed on Spark's app classloader for SparkPlugin).
     // Everything else (Spark, SLF4J, ByteBuddy, OTEL SDK) is provided.
-    assembly / assemblyJarName := "flare-spark.jar",
+    assembly / assemblyJarName := s"flare-spark-$sparkMajorMinor.jar",
     assembly / assemblyOption  := (assembly / assemblyOption).value
       .withIncludeScala(false),
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - spark-events:/opt/spark/spark-events
       - spark-logs:/opt/spark/logs
-      - ../target/scala-2.13/flare-spark.jar:/opt/flare/flare-spark.jar:ro
+      - ../target/scala-2.13/flare-spark-3.5.jar:/opt/flare/flare-spark.jar:ro
       - ../examples/target/scala-2.13/flare-examples.jar:/opt/flare/flare-examples.jar:ro
       - ./spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
       - ./entrypoint.sh:/entrypoint.sh:ro
@@ -48,7 +48,7 @@ services:
     ports:
       - "8081:8081"   # Worker UI
     volumes:
-      - ../target/scala-2.13/flare-spark.jar:/opt/flare/flare-spark.jar:ro
+      - ../target/scala-2.13/flare-spark-3.5.jar:/opt/flare/flare-spark.jar:ro
       - ../examples/target/scala-2.13/flare-examples.jar:/opt/flare/flare-examples.jar:ro
       - ./spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
       - ./entrypoint.sh:/entrypoint.sh:ro
@@ -71,7 +71,7 @@ services:
     ports:
       - "8082:8081"
     volumes:
-      - ../target/scala-2.13/flare-spark.jar:/opt/flare/flare-spark.jar:ro
+      - ../target/scala-2.13/flare-spark-3.5.jar:/opt/flare/flare-spark.jar:ro
       - ../examples/target/scala-2.13/flare-examples.jar:/opt/flare/flare-examples.jar:ro
       - ./spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
       - ./entrypoint.sh:/entrypoint.sh:ro

--- a/src/main/scala/io/flare/spark/config/FlareConfig.scala
+++ b/src/main/scala/io/flare/spark/config/FlareConfig.scala
@@ -1,5 +1,6 @@
 package io.flare.spark.config
 
+import scala.util.Try
 import scala.util.matching.Regex
 
 sealed trait TraceGranularity
@@ -97,7 +98,7 @@ object FlareConfig {
 
     val samplingRatio = envOrProp("FLARE_SAMPLING_RATIO")
       .map { s =>
-        val d = s.toDoubleOption.getOrElse(
+        val d = Try(s.toDouble).getOrElse(
           throw new IllegalArgumentException(s"Flare config error: FLARE_SAMPLING_RATIO '$s' is not a number")
         )
         if (d < 0.0 || d > 1.0)
@@ -108,7 +109,7 @@ object FlareConfig {
 
     val maxSpansPerTrace = envOrProp("FLARE_MAX_SPANS_PER_TRACE")
       .map { s =>
-        val n = s.toIntOption.getOrElse(
+        val n = Try(s.toInt).getOrElse(
           throw new IllegalArgumentException(s"Flare config error: FLARE_MAX_SPANS_PER_TRACE '$s' is not an integer")
         )
         if (n <= 0)
@@ -119,7 +120,7 @@ object FlareConfig {
 
     val slowTaskMs = envOrProp("FLARE_SLOW_TASK_MS")
       .map { s =>
-        val n = s.toLongOption.getOrElse(
+        val n = Try(s.toLong).getOrElse(
           throw new IllegalArgumentException(s"Flare config error: FLARE_SLOW_TASK_MS '$s' is not a number")
         )
         if (n < 0)
@@ -137,7 +138,7 @@ object FlareConfig {
     val taskStageIds = envOrProp("FLARE_TASK_STAGES")
       .map { s =>
         s.split(",").map(_.trim).filter(_.nonEmpty).map { id =>
-          id.toIntOption.getOrElse(
+          Try(id.toInt).getOrElse(
             throw new IllegalArgumentException(s"Flare config error: FLARE_TASK_STAGES '$id' is not an integer")
           )
         }.toSet

--- a/src/main/scala/io/flare/spark/instrumentation/SparkContextAdviceHelper.scala
+++ b/src/main/scala/io/flare/spark/instrumentation/SparkContextAdviceHelper.scala
@@ -29,7 +29,7 @@ import java.util.logging.{Level, Logger}
  */
 object SparkContextAdviceHelper {
 
-  private val logger = Logger.getLogger(classOf[SparkContextAdviceHelper.type].getName)
+  private val logger = Logger.getLogger(SparkContextAdviceHelper.getClass.getName)
 
   def onSparkContextInit(sc: SparkContext): Unit = {
     // Fast path: already initialized by SparkPlugin or a previous advice call

--- a/src/main/scala/io/flare/spark/instrumentation/SubmitMissingTasksAdviceHelper.scala
+++ b/src/main/scala/io/flare/spark/instrumentation/SubmitMissingTasksAdviceHelper.scala
@@ -39,7 +39,7 @@ import java.util.logging.{Level, Logger}
  */
 object SubmitMissingTasksAdviceHelper {
 
-  private val logger = Logger.getLogger(classOf[SubmitMissingTasksAdviceHelper.type].getName)
+  private val logger = Logger.getLogger(SubmitMissingTasksAdviceHelper.getClass.getName)
 
   /**
    * Job spans keyed by jobId. Created on first `submitMissingTasks` call for a

--- a/src/main/scala/io/flare/spark/instrumentation/TaskRunnerAdviceHelper.scala
+++ b/src/main/scala/io/flare/spark/instrumentation/TaskRunnerAdviceHelper.scala
@@ -24,7 +24,7 @@ import java.util.logging.{Level, Logger}
  */
 object TaskRunnerAdviceHelper {
 
-  private val logger = Logger.getLogger(classOf[TaskRunnerAdviceHelper.type].getName)
+  private val logger = Logger.getLogger(TaskRunnerAdviceHelper.getClass.getName)
 
   // Cached reflection — Method objects are thread-safe for invoke()
   @volatile private var propertiesMethod: java.lang.reflect.Method = _

--- a/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
+++ b/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
@@ -129,7 +129,7 @@ class TracingSparkListener(
   override def onJobEnd(event: SparkListenerJobEnd): Unit = {
     // Always clean up stageToJob, even if the job span was missed.
     // This prevents unbounded growth if onJobStart was lost due to listener registration timing.
-    stageToJob.filterInPlace { case (_, jobId) => jobId != event.jobId }
+    stageToJob.foreach { case (stageId, jId) => if (jId == event.jobId) stageToJob.remove(stageId) }
 
     // Clean up pre-created job span from the helper's map
     SubmitMissingTasksAdviceHelper.removeJobSpan(event.jobId)

--- a/src/main/scala/io/flare/spark/plugin/FlareDriverState.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareDriverState.scala
@@ -23,7 +23,7 @@ import java.util.logging.Logger
  */
 object FlareDriverState {
 
-  private val logger = Logger.getLogger(classOf[FlareDriverState.type].getName)
+  private val logger = Logger.getLogger(FlareDriverState.getClass.getName)
 
   @volatile private var _initialized: Boolean = false
   @volatile private[spark] var applicationSpan: Option[Span] = None

--- a/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
@@ -219,7 +219,7 @@ class FlareExecutorPlugin extends ExecutorPlugin {
 
         // SQL execution ID from local properties (captured context still has properties)
         Option(capturedTaskContext.getLocalProperty("spark.sql.execution.id"))
-          .flatMap(_.toLongOption)
+          .flatMap(s => scala.util.Try(s.toLong).toOption)
           .foreach(id => span.setLong(Task.SqlExecutionId, id))
 
         // Record OTEL metrics while span scope is still active → automatic exemplar linking.

--- a/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
+++ b/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
@@ -11,7 +11,7 @@ import munit.FunSuite
 import org.apache.spark.FlareTestHelpers
 import org.apache.spark.scheduler._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class TracingSparkListenerTest extends FunSuite {
 

--- a/src/test/scala/io/flare/spark/metrics/FlareMetricsTest.scala
+++ b/src/test/scala/io/flare/spark/metrics/FlareMetricsTest.scala
@@ -6,7 +6,7 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
 import munit.FunSuite
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class FlareMetricsTest extends FunSuite {
 


### PR DESCRIPTION
Closes #16

## Summary
- Dynamic artifact naming (`flare-spark-3.5.jar`, `flare-spark-4.0.jar`, etc.) via `-DsparkVersion` system property
- CI matrix with 7 build cells (Spark 3.3/3.4/3.5 × Scala 2.12/2.13, plus Spark 4.0 × Scala 2.13)
- Scala 2.12 compatibility fixes across source and test code
- Spark 4.0 automatically restricts `crossScalaVersions` to Scala 2.13 only

## Changes
- **build.sbt**: Dynamic `name`, `assemblyJarName`, `crossScalaVersions` based on `sparkMajorMinor`; `sparkVersion` added to BuildInfo; version-dependent `scalacOptions` moved from `ThisBuild` to root project
- **ci.yml**: 7-cell matrix strategy with `fail-fast: false`
- **Source (6 files)**: `classOf[X.type]` → `X.getClass`, `toIntOption`/`toLongOption`/`toDoubleOption` → `Try(_.toX)`, `filterInPlace` → `foreach`+`remove`
- **Tests (2 files)**: `scala.jdk.CollectionConverters` → `scala.collection.JavaConverters`
- **docker-compose.yml**: JAR path updated to `flare-spark-3.5.jar`
- **README.md**: Cross-compile instructions and supported matrix table

## Test plan
- [x] `sbt -DsparkVersion=3.3.4 ++2.12.18 compile test` — 73 tests pass
- [x] `sbt -DsparkVersion=3.5.1 ++2.13.16 compile test assembly` — 73 tests pass, produces `flare-spark-3.5.jar`
- [x] `sbt -DsparkVersion=4.0.0 ++2.13.16 compile test assembly` — 73 tests pass, produces `flare-spark-4.0.jar`
- [ ] CI matrix runs all 7 cells on push