### PR TITLE
Prefix metrics with flare_ to avoid Spark collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ docker compose exec spark-master \
 Open Grafana at `http://localhost:3000`:
 - **Dashboards > Flare — Spark Observability** — task duration heatmap, shuffle skew, executor comparison, stage summary, logs, and trace links
 - **Explore > Tempo** — search traces by service name, drill into span details with linked metrics and logs
-- **Explore > Mimir** — query spark_task_* and spark_stage_* metrics directly
+- **Explore > Mimir** — query flare_task_* and flare_stage_* metrics directly
 
 ## Architecture
 

--- a/docker/grafana/provisioning/dashboards/flare-spark.json
+++ b/docker/grafana/provisioning/dashboards/flare-spark.json
@@ -117,7 +117,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_task_duration_count)",
+          "expr": "sum(flare_task_duration_count)",
           "refId": "A",
           "instant": true
         }
@@ -156,7 +156,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_task_duration_count{task_result=\"FAILED\"}) / sum(spark_task_duration_count) or vector(0)",
+          "expr": "sum(flare_task_duration_count{task_result=\"FAILED\"}) / sum(flare_task_duration_count) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -200,7 +200,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_task_duration_bucket) by (le, stage_id)",
+          "expr": "sum(flare_task_duration_bucket) by (le, stage_id)",
           "refId": "A",
           "format": "heatmap",
           "legendFormat": "stage {{stage_id}}",
@@ -241,21 +241,21 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "histogram_quantile(0.50, sum(spark_task_duration_bucket) by (le))",
+          "expr": "histogram_quantile(0.50, sum(flare_task_duration_bucket) by (le))",
           "refId": "A",
           "instant": true,
           "legendFormat": "p50"
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "histogram_quantile(0.95, sum(spark_task_duration_bucket) by (le))",
+          "expr": "histogram_quantile(0.95, sum(flare_task_duration_bucket) by (le))",
           "refId": "B",
           "instant": true,
           "legendFormat": "p95"
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "histogram_quantile(0.99, sum(spark_task_duration_bucket) by (le))",
+          "expr": "histogram_quantile(0.99, sum(flare_task_duration_bucket) by (le))",
           "refId": "C",
           "instant": true,
           "legendFormat": "p99"
@@ -310,14 +310,14 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_task_shuffle_read_bytes) by (stage_id)",
+          "expr": "sum(flare_task_shuffle_read_bytes) by (stage_id)",
           "refId": "A",
           "instant": true,
           "legendFormat": "Read \u2014 stage {{stage_id}}"
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_task_shuffle_write_bytes) by (stage_id)",
+          "expr": "sum(flare_task_shuffle_write_bytes) by (stage_id)",
           "refId": "B",
           "instant": true,
           "legendFormat": "Write \u2014 stage {{stage_id}}"
@@ -365,14 +365,14 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_task_shuffle_read_bytes) by (executor_id)",
+          "expr": "sum(flare_task_shuffle_read_bytes) by (executor_id)",
           "refId": "A",
           "instant": true,
           "legendFormat": "Read \u2014 executor {{executor_id}}"
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_task_shuffle_write_bytes) by (executor_id)",
+          "expr": "sum(flare_task_shuffle_write_bytes) by (executor_id)",
           "refId": "B",
           "instant": true,
           "legendFormat": "Write \u2014 executor {{executor_id}}"
@@ -438,7 +438,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "histogram_quantile(0.95, sum(spark_stage_executor_run_time_bucket) by (le, stage_id, stage_name))",
+          "expr": "histogram_quantile(0.95, sum(flare_stage_executor_run_time_bucket) by (le, stage_id, stage_name))",
           "refId": "A",
           "instant": true,
           "legendFormat": "Executor Run Time p95",
@@ -446,7 +446,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_stage_input_bytes) by (stage_id, stage_name)",
+          "expr": "sum(flare_stage_input_bytes) by (stage_id, stage_name)",
           "refId": "B",
           "instant": true,
           "legendFormat": "Input",
@@ -454,7 +454,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_stage_shuffle_read_bytes) by (stage_id, stage_name)",
+          "expr": "sum(flare_stage_shuffle_read_bytes) by (stage_id, stage_name)",
           "refId": "C",
           "instant": true,
           "legendFormat": "Shuffle Read",
@@ -462,7 +462,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_stage_shuffle_write_bytes) by (stage_id, stage_name)",
+          "expr": "sum(flare_stage_shuffle_write_bytes) by (stage_id, stage_name)",
           "refId": "D",
           "instant": true,
           "legendFormat": "Shuffle Write",
@@ -537,7 +537,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_task_duration_sum) by (executor_id) / sum(spark_task_duration_count) by (executor_id)",
+          "expr": "sum(flare_task_duration_sum) by (executor_id) / sum(flare_task_duration_count) by (executor_id)",
           "refId": "A",
           "instant": true,
           "legendFormat": "executor {{executor_id}}"
@@ -584,7 +584,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(spark_task_duration_count) by (executor_id)",
+          "expr": "sum(flare_task_duration_count) by (executor_id)",
           "refId": "A",
           "instant": true,
           "legendFormat": "executor {{executor_id}}"

--- a/docker/grafana/provisioning/datasources/tempo.yaml
+++ b/docker/grafana/provisioning/datasources/tempo.yaml
@@ -20,23 +20,23 @@ datasources:
         spanEndTimeShift: '30m'
         queries:
           - name: Task Duration p95 (ms)
-            query: 'histogram_quantile(0.95, sum(spark_task_duration_bucket) by (le))'
+            query: 'histogram_quantile(0.95, sum(flare_task_duration_bucket) by (le))'
           - name: Avg Task Duration (ms)
-            query: 'sum(spark_task_duration_sum) / sum(spark_task_duration_count)'
+            query: 'sum(flare_task_duration_sum) / sum(flare_task_duration_count)'
           - name: Total Tasks
-            query: 'sum(spark_task_duration_count)'
+            query: 'sum(flare_task_duration_count)'
           - name: Shuffle Read (bytes)
-            query: 'sum(spark_task_shuffle_read_bytes)'
+            query: 'sum(flare_task_shuffle_read_bytes)'
           - name: Shuffle Write (bytes)
-            query: 'sum(spark_task_shuffle_write_bytes)'
+            query: 'sum(flare_task_shuffle_write_bytes)'
           - name: Stage Executor Run Time p95 (ms)
-            query: 'histogram_quantile(0.95, sum(spark_stage_executor_run_time_bucket) by (le))'
+            query: 'histogram_quantile(0.95, sum(flare_stage_executor_run_time_bucket) by (le))'
           - name: Stage Input (bytes)
-            query: 'sum(spark_stage_input_bytes)'
+            query: 'sum(flare_stage_input_bytes)'
           - name: Stage Shuffle Read (bytes)
-            query: 'sum(spark_stage_shuffle_read_bytes)'
+            query: 'sum(flare_stage_shuffle_read_bytes)'
           - name: Stage Shuffle Write (bytes)
-            query: 'sum(spark_stage_shuffle_write_bytes)'
+            query: 'sum(flare_stage_shuffle_write_bytes)'
       nodeGraph:
         enabled: true
       serviceMap:

--- a/src/main/scala/io/flare/spark/metrics/FlareMetrics.scala
+++ b/src/main/scala/io/flare/spark/metrics/FlareMetrics.scala
@@ -20,25 +20,25 @@ class FlareMetrics(meter: Meter) {
   // ── Executor-side (Issue #11) ──────────────────────────────────────────
 
   val taskDuration: DoubleHistogram = meter
-    .histogramBuilder("spark.task.duration")
+    .histogramBuilder("flare.task.duration")
     .setDescription("Task execution duration")
     .setUnit("ms")
     .build()
 
   val taskRecordsThroughput: DoubleHistogram = meter
-    .histogramBuilder("spark.task.records_throughput")
+    .histogramBuilder("flare.task.records_throughput")
     .setDescription("Task records processed per second")
     .setUnit("{records}/s")
     .build()
 
   val taskShuffleReadBytes: LongCounter = meter
-    .counterBuilder("spark.task.shuffle.read_bytes")
+    .counterBuilder("flare.task.shuffle.read_bytes")
     .setDescription("Bytes read during shuffle by individual tasks")
     .setUnit("By")
     .build()
 
   val taskShuffleWriteBytes: LongCounter = meter
-    .counterBuilder("spark.task.shuffle.write_bytes")
+    .counterBuilder("flare.task.shuffle.write_bytes")
     .setDescription("Bytes written during shuffle by individual tasks")
     .setUnit("By")
     .build()
@@ -46,31 +46,31 @@ class FlareMetrics(meter: Meter) {
   // ── Driver-side (Issue #10 partial) ────────────────────────────────────
 
   val stageExecutorRunTime: DoubleHistogram = meter
-    .histogramBuilder("spark.stage.executor.run_time")
+    .histogramBuilder("flare.stage.executor.run_time")
     .setDescription("Total executor run time per stage")
     .setUnit("ms")
     .build()
 
   val stageInputBytes: LongCounter = meter
-    .counterBuilder("spark.stage.input.bytes")
+    .counterBuilder("flare.stage.input.bytes")
     .setDescription("Total bytes read across all tasks in a stage")
     .setUnit("By")
     .build()
 
   val stageOutputBytes: LongCounter = meter
-    .counterBuilder("spark.stage.output.bytes")
+    .counterBuilder("flare.stage.output.bytes")
     .setDescription("Total bytes written across all tasks in a stage")
     .setUnit("By")
     .build()
 
   val stageShuffleReadBytes: LongCounter = meter
-    .counterBuilder("spark.stage.shuffle.read_bytes")
+    .counterBuilder("flare.stage.shuffle.read_bytes")
     .setDescription("Total shuffle bytes read in a stage")
     .setUnit("By")
     .build()
 
   val stageShuffleWriteBytes: LongCounter = meter
-    .counterBuilder("spark.stage.shuffle.write_bytes")
+    .counterBuilder("flare.stage.shuffle.write_bytes")
     .setDescription("Total shuffle bytes written in a stage")
     .setUnit("By")
     .build()

--- a/src/test/scala/io/flare/spark/metrics/FlareMetricsTest.scala
+++ b/src/test/scala/io/flare/spark/metrics/FlareMetricsTest.scala
@@ -27,7 +27,7 @@ class FlareMetricsTest extends FunSuite {
       metrics.taskDuration.record(150.0, attrs)
 
       val metricData = reader.collectAllMetrics().asScala
-      val histogram = metricData.find(_.getName == "spark.task.duration")
+      val histogram = metricData.find(_.getName == "flare.task.duration")
       assert(histogram.isDefined, s"Expected spark.task.duration, got: ${metricData.map(_.getName).mkString(", ")}")
     }
   }
@@ -38,7 +38,7 @@ class FlareMetricsTest extends FunSuite {
       metrics.taskRecordsThroughput.record(5000.0, attrs)
 
       val metricData = reader.collectAllMetrics().asScala
-      val histogram = metricData.find(_.getName == "spark.task.records_throughput")
+      val histogram = metricData.find(_.getName == "flare.task.records_throughput")
       assert(histogram.isDefined)
     }
   }
@@ -50,7 +50,7 @@ class FlareMetricsTest extends FunSuite {
       metrics.taskShuffleReadBytes.add(2048L, attrs)
 
       val metricData = reader.collectAllMetrics().asScala
-      val counter = metricData.find(_.getName == "spark.task.shuffle.read_bytes")
+      val counter = metricData.find(_.getName == "flare.task.shuffle.read_bytes")
       assert(counter.isDefined, s"Expected spark.task.shuffle.read_bytes, got: ${metricData.map(_.getName).mkString(", ")}")
     }
   }
@@ -64,9 +64,9 @@ class FlareMetricsTest extends FunSuite {
 
       val metricData = reader.collectAllMetrics().asScala
       val names = metricData.map(_.getName).toSet
-      assert(names.contains("spark.stage.executor.run_time"))
-      assert(names.contains("spark.stage.input.bytes"))
-      assert(names.contains("spark.stage.shuffle.read_bytes"))
+      assert(names.contains("flare.stage.executor.run_time"))
+      assert(names.contains("flare.stage.input.bytes"))
+      assert(names.contains("flare.stage.shuffle.read_bytes"))
     }
   }
 


### PR DESCRIPTION
Closes #31

## Summary
- Renames 9 OTEL metric instruments from `spark.*` to `flare.*` (e.g. `spark.task.duration` → `flare.task.duration`)
- Updates 17 PromQL queries in Grafana dashboard JSON
- Updates 9 tracesToMetrics queries in Tempo datasource config
- Updates test assertions and README
- Span names (`spark.stage.0`, `spark.task.executor`) and attribute keys (`spark.stage.id`, etc.) are **unchanged** — they live in trace backends, not Prometheus, so no collision risk

## Breaking change
Existing dashboard queries using `spark_task_*` or `spark_stage_*` will stop working. Users must update to `flare_task_*` and `flare_stage_*`.

## Test plan
- [x] 91 unit tests pass
- [x] E2E: SimpleJob ran, `flare_*` metrics confirmed in Mimir
- [x] E2E: SkewedJob ran, shuffle metrics confirmed
- [x] No `spark_task_*` or `spark_stage_*` metrics in Mimir (clean)
- [x] CI passes