### PR TITLE
Fix executor role detection, harden agent auto-config, repair dev stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AutoConfigurationCustomizerProvider` through ServiceLoader so `flare.role` and
   `flare.version` are emitted. Version metadata now comes from an sbt-generated classpath
   resource instead of nullable JAR package metadata
+- **Executor role detection** — `flare.role` fell back to `driver` on every standalone and YARN
+  executor, because only Kubernetes sets `SPARK_EXECUTOR_ID`. `FlareAutoConfig` now also parses
+  `--executor-id` out of `sun.java.command`, which is the only executor identity available at
+  agent premain ([#42])
+- **Missing build metadata is no longer fatal** — `loadFlareVersion()` warns and reports
+  `flare.version=unknown` instead of throwing. It runs inside the agent premain, so a repackaged
+  extension JAR that lost the resource would have aborted auto-configuration for the whole JVM
+  ([#42])
+- **Agent test port collision** — the reserved OTLP collector port is released before the test
+  JVM forks, so the stub collector now retries the bind and reports the real cause rather than
+  surfacing a bare `BindException` ([#42])
+
+### Documentation
+- **Resource attributes** — README documents `flare.role` and `flare.version`, how the role is
+  derived per deployment mode, and its cardinality behaviour under dynamic allocation ([#42])
 
 ## [0.2.0] - 2026-02-27
 
@@ -142,3 +157,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#10]: https://github.com/Neutrinic/flare/issues/10
 [#11]: https://github.com/Neutrinic/flare/issues/11
 [#26]: https://github.com/Neutrinic/flare/issues/26
+[#42]: https://github.com/Neutrinic/flare/issues/42

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,12 +84,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 - **Resource attributes** — README documents `flare.role` and `flare.version`, how the role is
   derived per deployment mode, and its cardinality behaviour under dynamic allocation ([#42])
-- **Installation options reordered** — `--packages` was labelled "recommended" but cannot load
-  the agent extension: it resolves into a per-node Ivy cache, so there is no stable path for
-  `-Dotel.javaagent.extensions`. Such deployments silently lose per-stage traceparent injection
-  (task spans parent to `spark.application` rather than their stage), in-task context
-  restoration, and the Flare resource attributes. Manual JAR deployment is now the recommended
-  option and the `--packages` caveats are spelled out ([#42])
+- **Installation options reordered** — `--packages` was labelled "recommended" but does not load
+  the agent extension: `-Dotel.javaagent.extensions` is read at premain from a fixed path, and
+  resolved packages are neither present nor at a nameable path by then. Such deployments silently
+  lose per-stage traceparent injection (task spans parent to `spark.application` rather than
+  their stage), in-task context restoration, and the Flare resource attributes. Manual JAR
+  deployment is now the recommended option and the `--packages` caveats are spelled out ([#42])
+- **Driver-side extension attachment documented** — `SparkContext` and `DAGScheduler` are both
+  driver-side, so attaching the extension on the driver alone restores per-stage traceparent
+  injection and `spark.task → spark.stage` parenting. Executors recover the correct parent from
+  task properties through the plugin without needing the extension. Useful where a stable JAR
+  path exists on the driver but not cluster-wide ([#42])
 
 ## [0.2.0] - 2026-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 - **Resource attributes** — README documents `flare.role` and `flare.version`, how the role is
   derived per deployment mode, and its cardinality behaviour under dynamic allocation ([#42])
+- **Installation options reordered** — `--packages` was labelled "recommended" but cannot load
+  the agent extension: it resolves into a per-node Ivy cache, so there is no stable path for
+  `-Dotel.javaagent.extensions`. Such deployments silently lose per-stage traceparent injection
+  (task spans parent to `spark.application` rather than their stage), in-task context
+  restoration, and the Flare resource attributes. Manual JAR deployment is now the recommended
+  option and the `--packages` caveats are spelled out ([#42])
 
 ## [0.2.0] - 2026-02-27
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,38 @@ Flare hooks `DAGScheduler.submitMissingTasks` via ByteBuddy to inject a per-stag
 
 ## Installation
 
-### Option 1: `--packages` (recommended)
+Flare is an OTEL Java agent **extension**. The agent loads it from a filesystem path given by
+`-Dotel.javaagent.extensions`, so the JAR must sit at a stable, identical path on every node.
+That requirement drives the two options below.
+
+### Option 1: Manual JAR deployment (recommended)
+
+```bash
+spark-submit \
+  --conf "spark.plugins=io.flare.spark.plugin.FlareSparkPlugin" \
+  --conf "spark.driver.extraClassPath=/opt/flare/flare-spark.jar" \
+  --conf "spark.executor.extraClassPath=/opt/flare/flare-spark.jar" \
+  --conf "spark.driver.extraJavaOptions=\
+    -javaagent:/opt/flare/opentelemetry-javaagent.jar \
+    -Dotel.javaagent.extensions=/opt/flare/flare-spark.jar \
+    -Dotel.service.name=my-app-driver \
+    -Dotel.exporter.otlp.protocol=grpc \
+    -Dotel.exporter.otlp.endpoint=http://your-collector:4317" \
+  --conf "spark.executor.extraJavaOptions=\
+    -javaagent:/opt/flare/opentelemetry-javaagent.jar \
+    -Dotel.javaagent.extensions=/opt/flare/flare-spark.jar \
+    -Dotel.service.name=my-app-executor \
+    -Dotel.exporter.otlp.protocol=grpc \
+    -Dotel.exporter.otlp.endpoint=http://your-collector:4317" \
+  myapp.jar
+```
+
+Both JARs must be accessible on every node. On Kubernetes, bake them into your Spark image. On YARN/EMR, use `--files` and reference via `{{PWD}}`.
+
+Download the JAR matching your Spark version from
+[Releases](https://github.com/Neutrinic/flare/releases), or pull it from Maven Central.
+
+### Option 2: `--packages` (reduced fidelity)
 
 ```bash
 spark-submit \
@@ -94,29 +125,17 @@ io.github.neutrinic:flare-spark-4-0_2.13:1.0.0   # Spark 4.0, Scala 2.13
 
 The OTEL Java agent JAR (`opentelemetry-javaagent.jar`) must still be placed on every node — `--packages` handles only Flare and its dependencies.
 
-### Option 2: Manual JAR deployment
-
-```bash
-spark-submit \
-  --conf "spark.plugins=io.flare.spark.plugin.FlareSparkPlugin" \
-  --conf "spark.driver.extraClassPath=/opt/flare/flare-spark.jar" \
-  --conf "spark.executor.extraClassPath=/opt/flare/flare-spark.jar" \
-  --conf "spark.driver.extraJavaOptions=\
-    -javaagent:/opt/flare/opentelemetry-javaagent.jar \
-    -Dotel.javaagent.extensions=/opt/flare/flare-spark.jar \
-    -Dotel.service.name=my-app-driver \
-    -Dotel.exporter.otlp.protocol=grpc \
-    -Dotel.exporter.otlp.endpoint=http://your-collector:4317" \
-  --conf "spark.executor.extraJavaOptions=\
-    -javaagent:/opt/flare/opentelemetry-javaagent.jar \
-    -Dotel.javaagent.extensions=/opt/flare/flare-spark.jar \
-    -Dotel.service.name=my-app-executor \
-    -Dotel.exporter.otlp.protocol=grpc \
-    -Dotel.exporter.otlp.endpoint=http://your-collector:4317" \
-  myapp.jar
-```
-
-Both JARs must be accessible on every node. On Kubernetes, bake them into your Spark image. On YARN/EMR, use `--files` and reference via `{{PWD}}`.
+> **`--packages` cannot load the agent extension.** It resolves into a per-node Ivy cache, so
+> there is no stable path to give `-Dotel.javaagent.extensions`. Flare still runs through
+> `spark.plugins` and still produces traces, but everything that ships as agent SPI is inactive:
+>
+> | Lost | Effect |
+> |------|--------|
+> | `SubmitMissingTasksInstrumentation` | No per-stage traceparent. Task spans parent to `spark.application` instead of their stage, so the hierarchy flattens to `app → task` alongside `app → job → stage`. AQE sub-jobs are missed |
+> | `TaskRunnerInstrumentationModule` | No OTEL context inside task bodies. JDBC/HTTP/gRPC calls made by your task code are not linked into the trace |
+> | `FlareAutoConfig` | No `flare.role` / `flare.version` resource attributes |
+>
+> Use this option only if a stable JAR path is genuinely unavailable in your environment.
 
 ## Configuration
 
@@ -136,8 +155,9 @@ any other value leaves it on.
 
 ### Resource Attributes
 
-Loaded as an agent extension, Flare adds two attributes to the OTEL `Resource`, so they appear on
-every span, metric and log record the JVM emits:
+Flare adds two attributes to the OTEL `Resource`, so they appear on every span, metric and log
+record the JVM emits. These come from the agent extension, so they are present with Option 1 and
+absent with Option 2:
 
 | Attribute | Example | Description |
 |-----------|---------|-------------|

--- a/README.md
+++ b/README.md
@@ -130,7 +130,26 @@ Both JARs must be accessible on every node. On Kubernetes, bake them into your S
 | `FLARE_METRICS_ENABLED` | `true` | Enable OTEL metrics (task duration, shuffle bytes, stage aggregates) |
 | `FLARE_ENABLED` | `true` | Kill switch |
 
-Set via `-DFLARE_*` in `extraJavaOptions` or as environment variables.
+Set via `-DFLARE_*` in `extraJavaOptions` or as environment variables. System properties take
+precedence. `FLARE_ENABLED` only disables Flare for the literal value `false` (case-insensitive);
+any other value leaves it on.
+
+### Resource Attributes
+
+Loaded as an agent extension, Flare adds two attributes to the OTEL `Resource`, so they appear on
+every span, metric and log record the JVM emits:
+
+| Attribute | Example | Description |
+|-----------|---------|-------------|
+| `flare.version` | `1.1.0` | Flare build version, or `unknown` if the build metadata is unreadable |
+| `flare.role` | `driver`, `executor-3` | Which side of the cluster the JVM is |
+
+`flare.role` comes from `SPARK_EXECUTOR_ID` where it exists (Kubernetes) and otherwise from the
+executor backend's `--executor-id` argument (standalone, YARN). It identifies the *individual*
+executor, so under dynamic allocation the set of values grows as executors churn. Most backends
+keep resource attributes off the metric series themselves — Prometheus-compatible stores expose
+them through `target_info` — but Loki promotes them, so weigh this against log stream cardinality
+if you run large elastic clusters.
 
 > **Note:** When a Spark job fails, exception messages are recorded as span attributes. Spark exceptions sometimes include snippets of the data being processed (e.g., parse errors, type mismatches). Ensure your telemetry backend is secured appropriately if your jobs handle sensitive data.
 

--- a/README.md
+++ b/README.md
@@ -125,17 +125,35 @@ io.github.neutrinic:flare-spark-4-0_2.13:1.0.0   # Spark 4.0, Scala 2.13
 
 The OTEL Java agent JAR (`opentelemetry-javaagent.jar`) must still be placed on every node — `--packages` handles only Flare and its dependencies.
 
-> **`--packages` cannot load the agent extension.** It resolves into a per-node Ivy cache, so
-> there is no stable path to give `-Dotel.javaagent.extensions`. Flare still runs through
-> `spark.plugins` and still produces traces, but everything that ships as agent SPI is inactive:
+> **`--packages` alone does not load the agent extension.** `-Dotel.javaagent.extensions` is read
+> at premain, from a fixed path. Resolved packages land in an Ivy cache on the driver and are
+> fetched into a per-application directory on executors at executor startup — in both cases too
+> late, and at a path you cannot name in advance. Flare still runs through `spark.plugins` and
+> still produces traces, but the agent SPI components are inactive:
 >
 > | Lost | Effect |
 > |------|--------|
 > | `SubmitMissingTasksInstrumentation` | No per-stage traceparent. Task spans parent to `spark.application` instead of their stage, so the hierarchy flattens to `app → task` alongside `app → job → stage`. AQE sub-jobs are missed |
 > | `TaskRunnerInstrumentationModule` | No OTEL context inside task bodies. JDBC/HTTP/gRPC calls made by your task code are not linked into the trace |
 > | `FlareAutoConfig` | No `flare.role` / `flare.version` resource attributes |
->
-> Use this option only if a stable JAR path is genuinely unavailable in your environment.
+
+#### Recovering stage attribution with a driver-side JAR
+
+The first row is the one that costs you most, and it is recoverable on its own. Both
+`SparkContext` and `DAGScheduler` live on the driver, so attaching the extension **only there**
+restores per-stage traceparent injection. Executors read it out of the task properties through
+the plugin and parent correctly, without needing the extension themselves:
+
+```bash
+  --conf "spark.driver.extraJavaOptions=\
+    -javaagent:/opt/flare/opentelemetry-javaagent.jar \
+    -Dotel.javaagent.extensions=/opt/flare/flare-spark.jar \
+    ..."
+```
+
+Verified: `spark.task → spark.stage` is restored, while executors report no `flare.role` and get
+no in-task context restoration. This only needs a stable path on the driver node, which is often
+available even when a cluster-wide one is not — notebooks and `spark-shell` in particular.
 
 ## Configuration
 

--- a/build.sbt
+++ b/build.sbt
@@ -137,6 +137,10 @@ lazy val root = (project in file("."))
         .find(_.getName == s"opentelemetry-javaagent-$otelAgentVersion.jar")
         .getOrElse(sys.error(s"Could not resolve OpenTelemetry Java agent $otelAgentVersion"))
       val extensionJar = (Compile / assembly).value
+      // The agent resolves the OTLP endpoint during premain, so the port has to be picked before
+      // the JVM forks and cannot be chosen by the test itself. Asking the OS for an ephemeral
+      // port and releasing it leaves a window where another process could claim it, so the test
+      // retries the bind and fails with an actionable message instead of a bare BindException.
       val collectorSocket =
         new java.net.ServerSocket(0, 1, java.net.InetAddress.getLoopbackAddress)
       val collectorPort = try collectorSocket.getLocalPort finally collectorSocket.close()

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -96,7 +96,7 @@ services:
   # ── Observability stack ───────────────────────────────────────────────────────
 
   alloy:
-    image: grafana/alloy:latest
+    image: grafana/alloy:v1.13.2
     hostname: alloy
     ports:
       - "4317:4317"   # OTLP gRPC (Spark → Alloy)
@@ -142,7 +142,7 @@ services:
     networks: [flare-net]
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:12.4.0
     hostname: grafana
     ports:
       - "3000:3000"

--- a/docker/grafana/provisioning/dashboards/flare-spark.json
+++ b/docker/grafana/provisioning/dashboards/flare-spark.json
@@ -45,7 +45,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(max_over_time(traces_spanmetrics_calls_total{span_name=~\"spark.job.*\"}[1h]))",
+          "expr": "sum(max_over_time(traces_spanmetrics_calls_total{span_name=~\"spark.job.*\"}[$__range]))",
           "refId": "A",
           "instant": true
         }
@@ -81,7 +81,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(max_over_time(traces_spanmetrics_calls_total{span_name=~\"spark.stage.*\"}[1h]))",
+          "expr": "sum(max_over_time(traces_spanmetrics_calls_total{span_name=~\"spark.stage.*\"}[$__range]))",
           "refId": "A",
           "instant": true
         }
@@ -117,7 +117,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(flare_task_duration_count)",
+          "expr": "sum(max_over_time(flare_task_duration_count[$__range]))",
           "refId": "A",
           "instant": true
         }
@@ -156,7 +156,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(flare_task_duration_count{task_result=\"FAILED\"}) / sum(flare_task_duration_count) or vector(0)",
+          "expr": "sum(max_over_time(flare_task_duration_count{task_result=\"FAILED\"}[$__range])) / sum(max_over_time(flare_task_duration_count[$__range])) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -241,21 +241,21 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "histogram_quantile(0.50, sum(flare_task_duration_bucket) by (le))",
+          "expr": "histogram_quantile(0.50, sum(max_over_time(flare_task_duration_bucket[$__range])) by (le))",
           "refId": "A",
           "instant": true,
           "legendFormat": "p50"
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "histogram_quantile(0.95, sum(flare_task_duration_bucket) by (le))",
+          "expr": "histogram_quantile(0.95, sum(max_over_time(flare_task_duration_bucket[$__range])) by (le))",
           "refId": "B",
           "instant": true,
           "legendFormat": "p95"
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "histogram_quantile(0.99, sum(flare_task_duration_bucket) by (le))",
+          "expr": "histogram_quantile(0.99, sum(max_over_time(flare_task_duration_bucket[$__range])) by (le))",
           "refId": "C",
           "instant": true,
           "legendFormat": "p99"
@@ -310,14 +310,14 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(flare_task_shuffle_read_bytes) by (stage_id)",
+          "expr": "sum(max_over_time(flare_task_shuffle_read_bytes[$__range])) by (stage_id)",
           "refId": "A",
           "instant": true,
           "legendFormat": "Read \u2014 stage {{stage_id}}"
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(flare_task_shuffle_write_bytes) by (stage_id)",
+          "expr": "sum(max_over_time(flare_task_shuffle_write_bytes[$__range])) by (stage_id)",
           "refId": "B",
           "instant": true,
           "legendFormat": "Write \u2014 stage {{stage_id}}"
@@ -365,14 +365,14 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(flare_task_shuffle_read_bytes) by (executor_id)",
+          "expr": "sum(max_over_time(flare_task_shuffle_read_bytes[$__range])) by (executor_id)",
           "refId": "A",
           "instant": true,
           "legendFormat": "Read \u2014 executor {{executor_id}}"
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(flare_task_shuffle_write_bytes) by (executor_id)",
+          "expr": "sum(max_over_time(flare_task_shuffle_write_bytes[$__range])) by (executor_id)",
           "refId": "B",
           "instant": true,
           "legendFormat": "Write \u2014 executor {{executor_id}}"
@@ -438,7 +438,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "histogram_quantile(0.95, sum(flare_stage_executor_run_time_bucket) by (le, stage_id, stage_name))",
+          "expr": "histogram_quantile(0.95, sum(max_over_time(flare_stage_executor_run_time_bucket[$__range])) by (le, stage_id, stage_name))",
           "refId": "A",
           "instant": true,
           "legendFormat": "Executor Run Time p95",
@@ -446,7 +446,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(flare_stage_input_bytes) by (stage_id, stage_name)",
+          "expr": "sum(max_over_time(flare_stage_input_bytes[$__range])) by (stage_id, stage_name)",
           "refId": "B",
           "instant": true,
           "legendFormat": "Input",
@@ -454,7 +454,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(flare_stage_shuffle_read_bytes) by (stage_id, stage_name)",
+          "expr": "sum(max_over_time(flare_stage_shuffle_read_bytes[$__range])) by (stage_id, stage_name)",
           "refId": "C",
           "instant": true,
           "legendFormat": "Shuffle Read",
@@ -462,7 +462,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(flare_stage_shuffle_write_bytes) by (stage_id, stage_name)",
+          "expr": "sum(max_over_time(flare_stage_shuffle_write_bytes[$__range])) by (stage_id, stage_name)",
           "refId": "D",
           "instant": true,
           "legendFormat": "Shuffle Write",
@@ -537,7 +537,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(flare_task_duration_sum) by (executor_id) / sum(flare_task_duration_count) by (executor_id)",
+          "expr": "sum(max_over_time(flare_task_duration_sum[$__range])) by (executor_id) / sum(max_over_time(flare_task_duration_count[$__range])) by (executor_id)",
           "refId": "A",
           "instant": true,
           "legendFormat": "executor {{executor_id}}"
@@ -584,7 +584,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "mimir" },
-          "expr": "sum(flare_task_duration_count) by (executor_id)",
+          "expr": "sum(max_over_time(flare_task_duration_count[$__range])) by (executor_id)",
           "refId": "A",
           "instant": true,
           "legendFormat": "executor {{executor_id}}"

--- a/docker/tempo-config.yaml
+++ b/docker/tempo-config.yaml
@@ -27,6 +27,18 @@ metrics_generator:
       dimensions:
         - service.name
       enable_target_info: true
+    # Required by TraceQL metrics queries, which back Grafana's Traces Drilldown.
+    # Without it the trace view fails with "localblocks processor not found".
+    local_blocks:
+      flush_to_storage: true
+      # Defaults to true, which keeps only SERVER-kind spans. Flare emits exactly one
+      # SERVER span (spark.application); jobs, stages and executor tasks are all
+      # INTERNAL, so the default silently drops everything worth drilling into.
+      filter_server_spans: false
+  # The local-blocks processor keeps whole traces, not just aggregates, so it needs
+  # its own WAL separate from the metrics WAL below.
+  traces_storage:
+    path: /var/tempo/generator/traces
   storage:
     path: /var/tempo/generator/wal
     remote_write:
@@ -39,6 +51,7 @@ overrides:
       processors:
         - service-graphs
         - span-metrics
+        - local-blocks
 
 storage:
   trace:

--- a/src/agentTest/scala/io/flare/spark/config/FlareAgentExtensionTest.scala
+++ b/src/agentTest/scala/io/flare/spark/config/FlareAgentExtensionTest.scala
@@ -119,6 +119,16 @@ class FlareAgentExtensionTest extends FunSuite {
     finally stream.close()
   }
 
+  /**
+   * Scans the raw OTLP payload for each required string.
+   *
+   * <p>This is a substring match over protobuf decoded as ISO-8859-1, chosen to keep a protobuf
+   * dependency out of the test. It proves each string appears somewhere in the export, not that
+   * it appears as the value of its own key. `expectedVersion` is distinctive enough for that to
+   * be a real assertion; `"driver"` is a short generic needle and only weakly implies that
+   * `flare.role` holds it. Treat this as a smoke test that the SPI ran and the attributes were
+   * exported — `FlareAutoConfigTest` is what pins the actual values.
+   */
   private def awaitPayload(
     requests: LinkedBlockingQueue[Array[Byte]],
     requiredStrings: Seq[String],

--- a/src/agentTest/scala/io/flare/spark/config/FlareAgentExtensionTest.scala
+++ b/src/agentTest/scala/io/flare/spark/config/FlareAgentExtensionTest.scala
@@ -4,7 +4,7 @@ import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
 import io.opentelemetry.api.GlobalOpenTelemetry
 import munit.FunSuite
 
-import java.net.InetSocketAddress
+import java.net.{BindException, InetSocketAddress}
 import java.nio.charset.StandardCharsets.{ISO_8859_1, UTF_8}
 import java.util.Properties
 import java.util.concurrent.{Executors, LinkedBlockingQueue, TimeUnit}
@@ -24,7 +24,7 @@ class FlareAgentExtensionTest extends FunSuite {
     val collectorPort = requiredProperty("flare.agent.test.collector.port").toInt
     val requests = new LinkedBlockingQueue[Array[Byte]]()
     val executor = Executors.newSingleThreadExecutor()
-    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", collectorPort), 0)
+    val server = bindCollector(collectorPort)
 
     server.createContext(
       "/v1/traces",
@@ -59,6 +59,34 @@ class FlareAgentExtensionTest extends FunSuite {
       server.stop(0)
       executor.shutdownNow()
     }
+  }
+
+  /**
+   * Binds the stub collector on the port the build reserved.
+   *
+   * <p>The build has to pick the port before this JVM forks, because the agent resolves the OTLP
+   * endpoint during premain. It therefore opens an ephemeral port and closes it again, which
+   * leaves a window for another process to take it. Retry briefly to ride out a transient
+   * collision, and otherwise fail with a message that names the actual cause.
+   */
+  private def bindCollector(port: Int): HttpServer = {
+    val address = new InetSocketAddress("127.0.0.1", port)
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    var lastFailure: BindException = null
+
+    while (System.nanoTime() < deadline) {
+      try return HttpServer.create(address, 0)
+      catch {
+        case failure: BindException =>
+          lastFailure = failure
+          Thread.sleep(250)
+      }
+    }
+
+    fail(
+      s"could not bind the stub OTLP collector on 127.0.0.1:$port — the build reserved this " +
+        s"port but another process claimed it before the test JVM started ($lastFailure)",
+    )
   }
 
   private def verifyAssembly(expectedVersion: String): Unit = {

--- a/src/main/java/io/flare/spark/config/FlareAutoConfig.java
+++ b/src/main/java/io/flare/spark/config/FlareAutoConfig.java
@@ -39,6 +39,14 @@ public class FlareAutoConfig implements AutoConfigurationCustomizerProvider {
         (resource, config) -> Resource.create(flareResourceAttributes()).merge(resource));
   }
 
+  /**
+   * Reads the {@code FLARE_ENABLED} kill switch: system property first, then environment, and only
+   * the literal value {@code "false"} disables Flare.
+   *
+   * <p>{@code FlareConfig.load()} parses the same key independently on the Scala side, because
+   * this class cannot reach the Scala runtime from the agent extension classloader. The two must
+   * agree; change them together.
+   */
   static boolean isFlareEnabled() {
     String configured = System.getProperty("FLARE_ENABLED");
     if (configured == null) {

--- a/src/main/java/io/flare/spark/config/FlareAutoConfig.java
+++ b/src/main/java/io/flare/spark/config/FlareAutoConfig.java
@@ -75,8 +75,32 @@ public class FlareAutoConfig implements AutoConfigurationCustomizerProvider {
     return version.trim();
   }
 
-  private static String detectRole() {
+  static String detectRole() {
     String executorId = System.getenv("SPARK_EXECUTOR_ID");
+    if (executorId == null || executorId.isEmpty()) {
+      executorId = executorIdFromCommand(System.getProperty("sun.java.command"));
+    }
     return executorId == null || executorId.isEmpty() ? "driver" : "executor-" + executorId;
+  }
+
+  /**
+   * Extracts the executor id from the JVM command line.
+   *
+   * <p>Only Kubernetes sets {@code SPARK_EXECUTOR_ID} in the executor environment. Standalone and
+   * YARN pass identity as a {@code --executor-id} argument to the executor backend, so without this
+   * fallback every executor would report itself as a driver.
+   */
+  static String executorIdFromCommand(String command) {
+    if (command == null || !command.contains("CoarseGrainedExecutorBackend")) {
+      return null;
+    }
+
+    String[] tokens = command.trim().split("\\s+");
+    for (int i = 0; i < tokens.length - 1; i++) {
+      if ("--executor-id".equals(tokens[i])) {
+        return tokens[i + 1];
+      }
+    }
+    return null;
   }
 }

--- a/src/main/java/io/flare/spark/config/FlareAutoConfig.java
+++ b/src/main/java/io/flare/spark/config/FlareAutoConfig.java
@@ -7,6 +7,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -23,6 +24,7 @@ public class FlareAutoConfig implements AutoConfigurationCustomizerProvider {
   private static final String BUILD_INFO_RESOURCE =
       "/io/flare/spark/flare-build.properties";
   private static final String FLARE_VERSION_PROPERTY = "flare.version";
+  private static final String UNKNOWN_VERSION = "unknown";
 
   private static final Logger logger = Logger.getLogger(FlareAutoConfig.class.getName());
 
@@ -52,25 +54,48 @@ public class FlareAutoConfig implements AutoConfigurationCustomizerProvider {
         .build();
   }
 
+  /**
+   * Reads the build-stamped Flare version, falling back to {@code "unknown"}.
+   *
+   * <p>This runs inside the agent's premain. Throwing here would abort auto-configuration for the
+   * whole JVM, so a repackaged or shaded extension jar that lost the metadata resource would take
+   * down the instrumented application rather than just mislabel it. A missing version is a
+   * cosmetic problem; it must never be a fatal one.
+   */
   static String loadFlareVersion() {
     Properties properties = new Properties();
 
     try (InputStream stream = FlareAutoConfig.class.getResourceAsStream(BUILD_INFO_RESOURCE)) {
       if (stream == null) {
-        throw new IllegalStateException(
-            "Missing Flare build metadata resource " + BUILD_INFO_RESOURCE);
+        logger.warning(
+            "[Flare] Missing build metadata resource "
+                + BUILD_INFO_RESOURCE
+                + ", reporting flare.version="
+                + UNKNOWN_VERSION);
+        return UNKNOWN_VERSION;
       }
       properties.load(stream);
     } catch (IOException exception) {
-      throw new IllegalStateException(
-          "Could not read Flare build metadata resource " + BUILD_INFO_RESOURCE,
+      logger.log(
+          Level.WARNING,
+          "[Flare] Could not read build metadata resource "
+              + BUILD_INFO_RESOURCE
+              + ", reporting flare.version="
+              + UNKNOWN_VERSION,
           exception);
+      return UNKNOWN_VERSION;
     }
 
     String version = properties.getProperty(FLARE_VERSION_PROPERTY);
     if (version == null || version.trim().isEmpty()) {
-      throw new IllegalStateException(
-          "Missing " + FLARE_VERSION_PROPERTY + " in " + BUILD_INFO_RESOURCE);
+      logger.warning(
+          "[Flare] Missing "
+              + FLARE_VERSION_PROPERTY
+              + " in "
+              + BUILD_INFO_RESOURCE
+              + ", reporting flare.version="
+              + UNKNOWN_VERSION);
+      return UNKNOWN_VERSION;
     }
     return version.trim();
   }

--- a/src/main/scala/io/flare/spark/config/FlareConfig.scala
+++ b/src/main/scala/io/flare/spark/config/FlareConfig.scala
@@ -86,6 +86,8 @@ object FlareConfig {
 
   /** Load and validate config from system properties / env vars. Throws at startup on invalid config. */
   def load(): FlareConfig = {
+    // Kept deliberately in step with FlareAutoConfig.isFlareEnabled(), which parses the same key
+    // in Java because the agent extension classloader has no Scala runtime. Change both together.
     val enabled = !envOrProp("FLARE_ENABLED")
       .map(_.toLowerCase).contains("false")
 

--- a/src/test/scala/io/flare/spark/config/FlareAutoConfigTest.scala
+++ b/src/test/scala/io/flare/spark/config/FlareAutoConfigTest.scala
@@ -34,9 +34,47 @@ class FlareAutoConfigTest extends FunSuite {
       attributes.get(AttributeKey.stringKey("flare.version")),
       sys.props("flare.test.expected.version"),
     )
-    assert(
-      Option(attributes.get(AttributeKey.stringKey("flare.role"))).exists(_.nonEmpty),
-      "flare.role must be present",
+    assertEquals(
+      attributes.get(AttributeKey.stringKey("flare.role")),
+      "driver",
+      "a JVM with no executor identity must report the driver role",
+    )
+  }
+
+  test("standalone executor identity is recovered from the JVM command line") {
+    val command =
+      "org.apache.spark.executor.CoarseGrainedExecutorBackend " +
+        "--driver-url spark://CoarseGrainedScheduler@spark-master:42649 " +
+        "--executor-id 7 --hostname 172.19.0.9 --cores 24 " +
+        "--app-id app-20260731150530-0000 " +
+        "--worker-url spark://Worker@172.19.0.9:43807 --resourceProfileId 0"
+
+    assertEquals(FlareAutoConfig.executorIdFromCommand(command), "7")
+  }
+
+  test("YARN executor backend is recognised as an executor") {
+    val command =
+      "org.apache.spark.executor.YarnCoarseGrainedExecutorBackend " +
+        "--driver-url spark://CoarseGrainedScheduler@host:1234 --executor-id 2 --cores 4"
+
+    assertEquals(FlareAutoConfig.executorIdFromCommand(command), "2")
+  }
+
+  test("driver command lines yield no executor id") {
+    val command =
+      "org.apache.spark.deploy.SparkSubmit --master spark://spark-master:7077 " +
+        "--class io.flare.examples.PipelineJob /opt/flare/flare-examples.jar"
+
+    assertEquals(FlareAutoConfig.executorIdFromCommand(command), null)
+    assertEquals(FlareAutoConfig.executorIdFromCommand(null), null)
+  }
+
+  test("executor backend without a parsable id does not fabricate one") {
+    assertEquals(
+      FlareAutoConfig.executorIdFromCommand(
+        "org.apache.spark.executor.CoarseGrainedExecutorBackend --cores 4 --executor-id",
+      ),
+      null,
     )
   }
 }

--- a/src/test/scala/io/flare/spark/config/FlareAutoConfigTest.scala
+++ b/src/test/scala/io/flare/spark/config/FlareAutoConfigTest.scala
@@ -77,4 +77,47 @@ class FlareAutoConfigTest extends FunSuite {
       null,
     )
   }
+
+  test("Flare is enabled unless FLARE_ENABLED explicitly disables it") {
+    if (sys.env.get("FLARE_ENABLED").isEmpty) {
+      assert(withFlareEnabled(None)(FlareAutoConfig.isFlareEnabled()), "absent means enabled")
+    }
+    assert(withFlareEnabled(Some("true"))(FlareAutoConfig.isFlareEnabled()))
+    assert(
+      withFlareEnabled(Some(""))(FlareAutoConfig.isFlareEnabled()),
+      "an empty value is not the string 'false', so it must not disable Flare",
+    )
+    assert(
+      withFlareEnabled(Some("no"))(FlareAutoConfig.isFlareEnabled()),
+      "only 'false' is a kill switch — other falsy-looking values must not silently disable Flare",
+    )
+  }
+
+  test("FLARE_ENABLED=false is honoured case-insensitively") {
+    assert(!withFlareEnabled(Some("false"))(FlareAutoConfig.isFlareEnabled()))
+    assert(!withFlareEnabled(Some("FALSE"))(FlareAutoConfig.isFlareEnabled()))
+    assert(!withFlareEnabled(Some("False"))(FlareAutoConfig.isFlareEnabled()))
+  }
+
+  test("build metadata version is reported rather than the unknown fallback") {
+    assertEquals(FlareAutoConfig.loadFlareVersion(), sys.props("flare.test.expected.version"))
+  }
+
+  /**
+   * Only the system property is exercised here. The environment variable is the other half of
+   * `isFlareEnabled`, but a JVM cannot portably mutate its own environment, and the agent reads
+   * the property first in any case.
+   */
+  private def withFlareEnabled[A](value: Option[String])(body: => A): A = {
+    val previous = Option(System.getProperty("FLARE_ENABLED"))
+    value match {
+      case Some(v) => System.setProperty("FLARE_ENABLED", v)
+      case None    => System.clearProperty("FLARE_ENABLED")
+    }
+    try body
+    finally previous match {
+      case Some(v) => System.setProperty("FLARE_ENABLED", v)
+      case None    => System.clearProperty("FLARE_ENABLED")
+    }
+  }
 }


### PR DESCRIPTION
Closes #42

## Summary

Covers items 1, 2, 3, 4, 5 and 6 of #42. Item 7 (bumping Loki/Mimir/Tempo) is deliberately left out — see below.

Two defects were found while doing item 5 that were not in the issue. Both are called out separately since they are the parts most worth reviewing.

### Executor role detection was broken (shipped in #41)

`flare.role` reported `driver` on **every** executor outside Kubernetes. Only K8s sets `SPARK_EXECUTOR_ID`; standalone and YARN pass identity as a `--executor-id N` argument to `(Yarn)CoarseGrainedExecutorBackend`. `detectRole()` read the environment variable only.

`detectRole()` runs at agent premain, long before `SparkEnv` exists, so the fallback parses `sun.java.command`. It mislabelled traces, metrics and logs alike.

The existing test asserted only that `flare.role` was non-empty, which is why this passed CI. It now asserts the value, with cases for standalone, YARN, driver command lines, and a malformed `--executor-id` with no argument.

### `--packages` does not load the agent extension, and was labelled "recommended"

`-Dotel.javaagent.extensions` is read at premain from a fixed path. Resolved packages land in an Ivy cache on the driver and in a per-application directory on executors, fetched at executor startup — in both cases after premain, at a path that cannot be named in advance.

Flare still traces via `spark.plugins`, so the failure is silent. Verified in the dev stack by submitting the same job in three shapes:

| Extension attached | Task parent | `flare.role` on executor |
|---|---|---|
| Driver + executors | `spark.stage` | present |
| Driver only | `spark.stage` | absent |
| Neither | `spark.application` | absent |

Documentation only. Manual JAR deployment is now Option 1, and Option 2 spells out what is lost.

**The middle row is worth attention.** `SparkContext` and `DAGScheduler` are both driver-side, and `FlareExecutorPlugin` parents task spans off whatever traceparent it extracts from task properties regardless of who wrote it. So attaching the extension on the driver alone restores stage attribution — the bulk of the fidelity gap — and needs a stable path on one node rather than cluster-wide. The README now documents this.

I had this backwards in an earlier revision of this branch, claiming a driver-only attachment would yield resource attributes and little else. Credit to review for catching it; `406095a` is the correction.

## Issue #42 items

| # | Item | Status |
|---|------|--------|
| 1 | `loadFlareVersion()` hard-throws | Warns, returns `unknown`, on all three failure paths |
| 2 | `isFlareEnabled()` untested | 7 assertions; both implementations cross-referenced |
| 3 | Port TOCTOU in `build.sbt` | Mitigated, not closed — see below |
| 4 | Weak OTLP substring assertion | Limitation documented, as the issue suggested |
| 5 | Verify dev stack on agent 2.30.0 | Done; found the two defects above plus three stack bugs |
| 6 | Pin floating image tags | `grafana:12.4.0`, `alloy:v1.13.2` |
| 7 | Bump observability stack | Not done — deliberately separate, see below |

**On item 3:** this cannot be fully fixed. The agent resolves the OTLP endpoint at premain, so the port must be chosen before the JVM forks, which means the build must open an ephemeral port and release it. The test now retries the bind and fails with the real cause instead of a bare `BindException`. Closing it properly means replacing the network collector with an in-process exporter, which is a larger change than this PR should carry.

**On item 7:** the issue asks for it in a separate commit so dashboard regressions stay bisectable. Since this PR already rewrites most dashboard queries, a stack bump on top would make any regression ambiguous. Better as its own PR against a known-good baseline.

## Dev stack fixes

Item 5 surfaced three problems that made the stack unusable for verification:

- **Tempo Traces Drilldown was empty.** Three separate causes, each failing differently: the `local-blocks` processor was absent (Grafana errors outright), it had no `traces_storage` WAL (empty series, no error), and `filter_server_spans` defaults to `true`. That last one keeps only SERVER-kind spans — Flare emits exactly one, `spark.application`, so every job, stage and task span was silently discarded.
- **14 of 18 dashboard panels went blank** roughly 5 minutes after a job finished. Spark is bursty batch work and Prometheus instant queries only look back 5 minutes. All instant targets are now wrapped in `max_over_time(...[$__range])`. This also fixes the `TypeError: Cannot read properties of undefined (reading '0')` on the barcharts, which were choking on empty frames.
- **Floating image tags** pinned (item 6).

## Untested and deliberately undocumented

On YARN, `--packages` merges into `spark.yarn.dist.jars`, and those are localized into the container working directory by the NodeManager *before* the JVM launches — which is a different mechanism from the executor-startup fetch above. If that holds, a CWD-relative `-Dotel.javaagent.extensions=./flare-spark-...jar` would work on YARN and the whole caveat would shrink to a docs paragraph.

Given the download mix skews heavily to the 3.5/2.12 artifact, this may not be a corner case for actual users. I have not smoke-tested it — the dev stack is standalone — so it is not in the README. Worth a follow-up issue.

## Not addressed

`flare.role` is `executor-<id>`, so under dynamic allocation the value set grows as executors churn. This is unchanged behaviour and the README now documents it, but whether the attribute should be coarse (`executor`) rather than per-executor is a real decision that belongs with the 1.1.0 release, not here.

## Test plan

- [x] `sbt -DsparkVersion=3.5.1 ++2.13.16 test` — 100 passed
- [x] `sbt -DsparkVersion=3.5.1 ++2.12.18 test` — 100 passed
- [x] `sbt -DsparkVersion=3.5.1 ++2.13.16 "AgentTest / test"` — 1 passed
- [x] Dev stack end-to-end on agent 2.30.0: `PipelineJob` produces 3 SQL executions, 8 jobs, 8 stages, 13 task spans
- [x] All three signals carry the corrected role: Tempo spans, Mimir `target_info` (`driver`, `executor-0`, `executor-1`), Loki structured metadata
- [x] TraceQL metrics return non-zero samples for `flare-executor` and `spark.task.executor`, which they did not before
- [x] Stack verified after pinning, not just before
- [x] Extension attachment matrix (both / driver-only / neither) verified against trace parentage
- [ ] YARN `--packages` localization — not tested, see above