### PR TITLE
Attach SQL execution metadata to spark.sql spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **SQL execution metadata on `spark.sql.N` spans** — the span previously carried no attributes
+  at all. It now records `spark.sql.execution.id`, `spark.sql.description`, `spark.sql.details`
+  and `spark.sql.plan` (the formatted physical plan), all sourced from
+  `SparkListenerSQLExecutionStart`. `spark.sql.description` is Spark's own query label, e.g.
+  `count at PipelineJob.scala:43`, which identifies a query far better than the stage names
+  derived from `RDD.creationSite`.
+  Free-form strings are capped — plan at 4096 characters, details at 2048, description at 1024 —
+  because they are unbounded at the source, and one oversized attribute can push an OTLP batch
+  past a collector's message limit, dropping the entire batch rather than just the plan. A
+  clipped plan sets `spark.sql.plan.truncated=true`, so a partial plan is never mistaken for a
+  complete one. Empty or absent values are omitted rather than exported as empty attributes.
+  Per-operator metrics from `sparkPlanInfo` are not included ([#44], tracked in [#47])
 - **Real-agent extension test** — a forked JVM runs the supported OpenTelemetry Java agent with
   Flare's assembled JAR, then verifies the packaged SPI descriptor, generated version metadata,
   and exported `flare.role` / `flare.version` resource attributes
@@ -169,3 +181,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#11]: https://github.com/Neutrinic/flare/issues/11
 [#26]: https://github.com/Neutrinic/flare/issues/26
 [#42]: https://github.com/Neutrinic/flare/issues/42
+[#44]: https://github.com/Neutrinic/flare/issues/44
+[#47]: https://github.com/Neutrinic/flare/issues/47

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clipped plan sets `spark.sql.plan.truncated=true`, so a partial plan is never mistaken for a
   complete one. Empty or absent values are omitted rather than exported as empty attributes.
   Per-operator metrics from `sparkPlanInfo` are not included ([#44], tracked in [#47])
+- **`FLARE_SQL_PLAN_MAX_CHARS` / `FLARE_SQL_DETAILS_MAX_CHARS` /
+  `FLARE_SQL_DESCRIPTION_MAX_CHARS`** — the SQL truncation caps above are now configurable rather
+  than compiled in, so a deployment whose collector accepts larger payloads can keep the whole
+  plan. Setting a cap to `0` drops that attribute entirely; a negative value is rejected at
+  startup ([#44])
 - **Real-agent extension test** — a forked JVM runs the supported OpenTelemetry Java agent with
   Flare's assembled JAR, then verifies the packaged SPI descriptor, generated version metadata,
   and exported `flare.role` / `flare.version` resource attributes

--- a/README.md
+++ b/README.md
@@ -165,11 +165,20 @@ available even when a cluster-wide one is not — notebooks and `spark-shell` in
 | `FLARE_RETRY_TASKS_ONLY` | `false` | Only emit spans for retries and speculative tasks |
 | `FLARE_MAX_SPANS_PER_TRACE` | `10000` | Circuit breaker for high-cardinality jobs |
 | `FLARE_METRICS_ENABLED` | `true` | Enable OTEL metrics (task duration, shuffle bytes, stage aggregates) |
+| `FLARE_SQL_PLAN_MAX_CHARS` | `4096` | Cap on `spark.sql.plan`; `0` drops the attribute |
+| `FLARE_SQL_DETAILS_MAX_CHARS` | `2048` | Cap on `spark.sql.details`; `0` drops the attribute |
+| `FLARE_SQL_DESCRIPTION_MAX_CHARS` | `1024` | Cap on `spark.sql.description`; `0` drops the attribute |
 | `FLARE_ENABLED` | `true` | Kill switch |
 
 Set via `-DFLARE_*` in `extraJavaOptions` or as environment variables. System properties take
 precedence. `FLARE_ENABLED` only disables Flare for the literal value `false` (case-insensitive);
 any other value leaves it on.
+
+The SQL caps exist because a physical plan is unbounded at the source — a wide query runs to tens
+of kilobytes, which is enough to push an OTLP batch past a collector's message limit, dropping the
+whole batch rather than just the plan. Raise `FLARE_SQL_PLAN_MAX_CHARS` if your collector accepts
+larger payloads. When a plan is clipped, `spark.sql.plan.truncated=true` is set alongside it, so a
+partial plan never reads as a complete one.
 
 ### Resource Attributes
 

--- a/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
+++ b/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
@@ -35,6 +35,22 @@ object SparkAttributes {
     val FailureReason   = AttributeKey.stringKey("spark.stage.failure_reason")
   }
 
+  /**
+   * Attributes on the `spark.sql.N` span, sourced from SparkListenerSQLExecutionStart.
+   *
+   * Fields are read by name rather than by position: Spark has both added fields
+   * (`modifiedConfigs`, `jobTags`) and inserted them ahead of `description`
+   * (`rootExecutionId` in 4.0) across the supported matrix.
+   */
+  object Sql {
+    val ExecutionId = AttributeKey.longKey("spark.sql.execution.id")
+    val Description = AttributeKey.stringKey("spark.sql.description")
+    val Details     = AttributeKey.stringKey("spark.sql.details")
+    // physicalPlanDescription — the formatted plan, truncated on the way in.
+    val Plan          = AttributeKey.stringKey("spark.sql.plan")
+    val PlanTruncated = AttributeKey.booleanKey("spark.sql.plan.truncated")
+  }
+
   object Task {
     val ExecutorId  = AttributeKey.stringKey("spark.task.executor.id")
     val Host        = AttributeKey.stringKey("spark.task.host")

--- a/src/main/scala/io/flare/spark/config/FlareConfig.scala
+++ b/src/main/scala/io/flare/spark/config/FlareConfig.scala
@@ -33,6 +33,11 @@ final case class FlareConfig(
   // Compiled once at load time, not per task.
   taskStagePattern: Option[Regex],
   metricsEnabled:   Boolean,      // FLARE_METRICS_ENABLED, default true
+  // Caps for the free-form strings on SparkListenerSQLExecutionStart. 0 drops the
+  // attribute entirely. See FlareConfig.DefaultSql*Chars for why these exist.
+  sqlPlanMaxChars:        Int = FlareConfig.DefaultSqlPlanChars,
+  sqlDetailsMaxChars:     Int = FlareConfig.DefaultSqlDetailsChars,
+  sqlDescriptionMaxChars: Int = FlareConfig.DefaultSqlDescriptionChars,
 ) {
   def tracesJobs:        Boolean = enabled
   def tracesStages:      Boolean = enabled && granularity != TraceGranularity.Jobs
@@ -74,6 +79,26 @@ final case class FlareConfig(
 }
 
 object FlareConfig {
+
+  /**
+   * Caps for the free-form strings on SparkListenerSQLExecutionStart.
+   *
+   * These are unbounded at the source. A wide query plan runs to tens of kilobytes, and one
+   * attribute per SQL execution at that size is enough to push an OTLP batch over a collector's
+   * message limit — at which point the whole batch is dropped, not just the plan. The caps trade
+   * a partial plan for a delivered trace.
+   *
+   * The plan cap is deliberately far larger than the 500 used for `Stage.FailureReason`: a
+   * failure reason is readable in its first line, whereas a plan truncated to 500 chars loses
+   * every operator that matters.
+   *
+   * Override per deployment with FLARE_SQL_PLAN_MAX_CHARS / FLARE_SQL_DETAILS_MAX_CHARS /
+   * FLARE_SQL_DESCRIPTION_MAX_CHARS. Raise them if your collector accepts larger payloads;
+   * set one to 0 to drop that attribute entirely.
+   */
+  val DefaultSqlPlanChars        = 4096
+  val DefaultSqlDetailsChars     = 2048
+  val DefaultSqlDescriptionChars = 1024
 
   /**
    * Read a config value from system properties first, then environment variables.
@@ -160,6 +185,18 @@ object FlareConfig {
     val metricsEnabled = !envOrProp("FLARE_METRICS_ENABLED")
       .map(_.toLowerCase).contains("false")
 
+    // 0 is legal and means "drop this attribute"; negative is a typo, not an intent.
+    def charCap(key: String, default: Int): Int = envOrProp(key)
+      .map { s =>
+        val n = Try(s.toInt).getOrElse(
+          throw new IllegalArgumentException(s"Flare config error: $key '$s' is not an integer")
+        )
+        if (n < 0)
+          throw new IllegalArgumentException(s"Flare config error: $key must be >= 0, got $n")
+        n
+      }
+      .getOrElse(default)
+
     FlareConfig(
       enabled          = enabled,
       granularity      = granularity,
@@ -170,6 +207,9 @@ object FlareConfig {
       taskStageIds     = taskStageIds,
       taskStagePattern = taskStagePattern,
       metricsEnabled   = metricsEnabled,
+      sqlPlanMaxChars        = charCap("FLARE_SQL_PLAN_MAX_CHARS", DefaultSqlPlanChars),
+      sqlDetailsMaxChars     = charCap("FLARE_SQL_DETAILS_MAX_CHARS", DefaultSqlDetailsChars),
+      sqlDescriptionMaxChars = charCap("FLARE_SQL_DESCRIPTION_MAX_CHARS", DefaultSqlDescriptionChars),
     )
   }
 }

--- a/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
+++ b/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
@@ -4,6 +4,11 @@ import io.flare.spark.SpanCompat._
 import io.flare.spark.attributes.SparkAttributes._
 import io.flare.spark.config.FlareConfig
 import io.flare.spark.instrumentation.SubmitMissingTasksAdviceHelper
+import io.flare.spark.listener.TracingSparkListener.{
+  MaxDescriptionChars,
+  MaxDetailsChars,
+  MaxPlanChars,
+}
 import io.flare.spark.metrics.{FlareMetrics, MetricAttributes}
 import io.opentelemetry.api.trace.{Span, SpanKind, StatusCode, Tracer}
 import io.opentelemetry.context.Context
@@ -249,6 +254,16 @@ class TracingSparkListener(
               .setSpanKind(SpanKind.INTERNAL)
               .setParent(Context.current().`with`(parent))
               .startSpan()
+
+            // Fields are read by name, never positionally — see describeSqlExecution.
+            describeSqlExecution(
+              span,
+              e.executionId,
+              e.description,
+              e.details,
+              e.physicalPlanDescription,
+            )
+
             // Store in shared map so advice and onJobStart can parent jobs under SQL
             SubmitMissingTasksAdviceHelper.activeSQLSpans.put(e.executionId, span)
           }
@@ -287,4 +302,72 @@ class TracingSparkListener(
         logger.error(s"[Flare] Error handling $eventName: ${ex.getMessage}", ex)
         if (throwOnError) throw ex
     }
+
+  /**
+   * Applies SparkListenerSQLExecutionStart metadata to the `spark.sql.N` span.
+   *
+   * Takes loose values rather than the event itself, deliberately. The event's constructor is not
+   * source-compatible across the supported Spark matrix — 3.4 inserted `rootExecutionId` as the
+   * second parameter, and 4.0 appended `jobTags` and `jobGroupId`:
+   *
+   * {{{
+   * 3.3: (executionId, description, details, physicalPlanDescription, sparkPlanInfo, time, modifiedConfigs)
+   * 3.4: (executionId, rootExecutionId, description, ..., modifiedConfigs)
+   * 4.0: (executionId, rootExecutionId, description, ..., modifiedConfigs, jobTags, jobGroupId)
+   * }}}
+   *
+   * Reading fields by name at the single call site compiles everywhere; constructing one does
+   * not, so no shared test source set can build a fixture. Keeping the logic here means it stays
+   * directly testable without a Spark event at all.
+   */
+  private[listener] def describeSqlExecution(
+    span:                    Span,
+    executionId:             Long,
+    description:             String,
+    details:                 String,
+    physicalPlanDescription: String,
+  ): Unit = {
+    span.setLong(Sql.ExecutionId, executionId)
+    // Spark leaves these empty on some execution paths; an empty attribute is pure noise.
+    setIfNonEmpty(span, Sql.Description, description, MaxDescriptionChars)
+    setIfNonEmpty(span, Sql.Details, details, MaxDetailsChars)
+
+    val plan = Option(physicalPlanDescription).getOrElse("")
+    if (plan.nonEmpty) {
+      span.setAttribute(Sql.Plan, plan.take(MaxPlanChars))
+      // Flag truncation explicitly. A silently clipped plan reads exactly like a complete one,
+      // which is worse than no plan at all when someone is diagnosing a slow join.
+      if (plan.length > MaxPlanChars) span.setBool(Sql.PlanTruncated, true)
+    }
+  }
+
+  /** Sets `key` only when Spark actually supplied a value, capping it at `maxChars`. */
+  private def setIfNonEmpty(
+    span:     Span,
+    key:      io.opentelemetry.api.common.AttributeKey[String],
+    value:    String,
+    maxChars: Int,
+  ): Unit = {
+    val v = Option(value).getOrElse("")
+    if (v.nonEmpty) span.setAttribute(key, v.take(maxChars))
+  }
+}
+
+object TracingSparkListener {
+
+  /**
+   * Caps for the free-form strings on SparkListenerSQLExecutionStart.
+   *
+   * These are unbounded at the source. A wide query plan runs to tens of kilobytes, and one
+   * attribute per SQL execution at that size is enough to push an OTLP batch over a collector's
+   * message limit — at which point the whole batch is dropped, not just the plan. The caps trade
+   * a partial plan for a delivered trace.
+   *
+   * The plan cap is deliberately far larger than the 500 used for `Stage.FailureReason`: a
+   * failure reason is readable in its first line, whereas a plan truncated to 500 chars loses
+   * every operator that matters.
+   */
+  private[listener] val MaxPlanChars        = 4096
+  private[listener] val MaxDetailsChars     = 2048
+  private[listener] val MaxDescriptionChars = 1024
 }

--- a/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
+++ b/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
@@ -4,11 +4,6 @@ import io.flare.spark.SpanCompat._
 import io.flare.spark.attributes.SparkAttributes._
 import io.flare.spark.config.FlareConfig
 import io.flare.spark.instrumentation.SubmitMissingTasksAdviceHelper
-import io.flare.spark.listener.TracingSparkListener.{
-  MaxDescriptionChars,
-  MaxDetailsChars,
-  MaxPlanChars,
-}
 import io.flare.spark.metrics.{FlareMetrics, MetricAttributes}
 import io.opentelemetry.api.trace.{Span, SpanKind, StatusCode, Tracer}
 import io.opentelemetry.context.Context
@@ -329,19 +324,19 @@ class TracingSparkListener(
   ): Unit = {
     span.setLong(Sql.ExecutionId, executionId)
     // Spark leaves these empty on some execution paths; an empty attribute is pure noise.
-    setIfNonEmpty(span, Sql.Description, description, MaxDescriptionChars)
-    setIfNonEmpty(span, Sql.Details, details, MaxDetailsChars)
+    setIfNonEmpty(span, Sql.Description, description, config.sqlDescriptionMaxChars)
+    setIfNonEmpty(span, Sql.Details, details, config.sqlDetailsMaxChars)
 
     val plan = Option(physicalPlanDescription).getOrElse("")
-    if (plan.nonEmpty) {
-      span.setAttribute(Sql.Plan, plan.take(MaxPlanChars))
+    if (plan.nonEmpty && config.sqlPlanMaxChars > 0) {
+      span.setAttribute(Sql.Plan, plan.take(config.sqlPlanMaxChars))
       // Flag truncation explicitly. A silently clipped plan reads exactly like a complete one,
       // which is worse than no plan at all when someone is diagnosing a slow join.
-      if (plan.length > MaxPlanChars) span.setBool(Sql.PlanTruncated, true)
+      if (plan.length > config.sqlPlanMaxChars) span.setBool(Sql.PlanTruncated, true)
     }
   }
 
-  /** Sets `key` only when Spark actually supplied a value, capping it at `maxChars`. */
+  /** Sets `key` only when Spark supplied a value and the cap allows it. `maxChars = 0` drops it. */
   private def setIfNonEmpty(
     span:     Span,
     key:      io.opentelemetry.api.common.AttributeKey[String],
@@ -349,25 +344,6 @@ class TracingSparkListener(
     maxChars: Int,
   ): Unit = {
     val v = Option(value).getOrElse("")
-    if (v.nonEmpty) span.setAttribute(key, v.take(maxChars))
+    if (v.nonEmpty && maxChars > 0) span.setAttribute(key, v.take(maxChars))
   }
-}
-
-object TracingSparkListener {
-
-  /**
-   * Caps for the free-form strings on SparkListenerSQLExecutionStart.
-   *
-   * These are unbounded at the source. A wide query plan runs to tens of kilobytes, and one
-   * attribute per SQL execution at that size is enough to push an OTLP batch over a collector's
-   * message limit — at which point the whole batch is dropped, not just the plan. The caps trade
-   * a partial plan for a delivered trace.
-   *
-   * The plan cap is deliberately far larger than the 500 used for `Stage.FailureReason`: a
-   * failure reason is readable in its first line, whereas a plan truncated to 500 chars loses
-   * every operator that matters.
-   */
-  private[listener] val MaxPlanChars        = 4096
-  private[listener] val MaxDetailsChars     = 2048
-  private[listener] val MaxDescriptionChars = 1024
 }

--- a/src/test/scala/io/flare/spark/config/FlareConfigTest.scala
+++ b/src/test/scala/io/flare/spark/config/FlareConfigTest.scala
@@ -136,6 +136,7 @@ class FlareConfigTest extends FunSuite {
     "FLARE_ENABLED", "FLARE_TRACE_GRANULARITY", "FLARE_SAMPLING_RATIO",
     "FLARE_MAX_SPANS_PER_TRACE", "FLARE_SLOW_TASK_MS", "FLARE_RETRY_TASKS_ONLY",
     "FLARE_TASK_STAGES", "FLARE_TASK_STAGE_PATTERN", "FLARE_METRICS_ENABLED",
+    "FLARE_SQL_PLAN_MAX_CHARS", "FLARE_SQL_DETAILS_MAX_CHARS", "FLARE_SQL_DESCRIPTION_MAX_CHARS",
   )
 
   override def afterEach(context: AfterEach): Unit = {
@@ -202,6 +203,37 @@ class FlareConfigTest extends FunSuite {
     assert(config.taskStageIds.isEmpty)
     assert(config.taskStagePattern.isEmpty)
     assert(config.metricsEnabled)
+    assertEquals(config.sqlPlanMaxChars, 4096)
+    assertEquals(config.sqlDetailsMaxChars, 2048)
+    assertEquals(config.sqlDescriptionMaxChars, 1024)
+  }
+
+  test("load() parses the SQL truncation caps") {
+    sys.props("FLARE_SQL_PLAN_MAX_CHARS")        = "65536"
+    sys.props("FLARE_SQL_DETAILS_MAX_CHARS")     = "0"
+    sys.props("FLARE_SQL_DESCRIPTION_MAX_CHARS") = "256"
+    val config = FlareConfig.load()
+    assertEquals(config.sqlPlanMaxChars, 65536)
+    assertEquals(config.sqlDetailsMaxChars, 0)
+    assertEquals(config.sqlDescriptionMaxChars, 256)
+  }
+
+  test("load() throws on a negative SQL truncation cap") {
+    sys.props("FLARE_SQL_PLAN_MAX_CHARS") = "-1"
+    interceptMessage[IllegalArgumentException](
+      "Flare config error: FLARE_SQL_PLAN_MAX_CHARS must be >= 0, got -1"
+    ) {
+      FlareConfig.load()
+    }
+  }
+
+  test("load() throws on a non-integer SQL truncation cap") {
+    sys.props("FLARE_SQL_DETAILS_MAX_CHARS") = "4k"
+    interceptMessage[IllegalArgumentException](
+      "Flare config error: FLARE_SQL_DETAILS_MAX_CHARS '4k' is not an integer"
+    ) {
+      FlareConfig.load()
+    }
   }
 
   test("load() FLARE_METRICS_ENABLED=false disables metrics") {

--- a/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
+++ b/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
@@ -3,6 +3,7 @@ package io.flare.spark.listener
 import io.flare.spark.attributes.SparkAttributes._
 import io.flare.spark.config.{FlareConfig, TraceGranularity}
 import io.flare.spark.instrumentation.SubmitMissingTasksAdviceHelper
+import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.{SpanKind, StatusCode}
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
@@ -364,6 +365,83 @@ class TracingSparkListenerTest extends FunSuite {
       // Stage is child of job
       assertEquals(stgSpan.getParentSpanId, jobSpanData.getSpanId)
     }
+  }
+
+  /**
+   * Runs describeSqlExecution against a real span and returns the exported attributes.
+   *
+   * The listener's SQL branch deliberately is not driven end to end from here.
+   * SparkListenerSQLExecutionStart changes constructor shape across the supported matrix —
+   * 3.4 inserts `rootExecutionId` second, 4.0 appends `jobTags` and `jobGroupId` — so any
+   * fixture that compiles on 3.5 fails to compile on 3.3. Calling the method directly keeps
+   * this logic covered on every version we build.
+   */
+  def sqlAttributes(
+    description: String = "",
+    details:     String = "",
+    plan:        String = "",
+    executionId: Long   = 7L,
+  ): Attributes = {
+    val exporter = InMemorySpanExporter.create()
+    val provider = SdkTracerProvider.builder()
+      .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+      .build()
+    try {
+      val tracer   = provider.get("io.flare.spark.test")
+      val listener = new TracingSparkListener(tracer, config, throwOnError = true)
+      val span     = tracer.spanBuilder(s"spark.sql.$executionId").startSpan()
+      listener.describeSqlExecution(span, executionId, description, details, plan)
+      span.end()
+      exporter.getFinishedSpanItems.asScala.head.getAttributes
+    } finally provider.close()
+  }
+
+  test("SQL execution metadata is attached to the spark.sql span") {
+    val attrs = sqlAttributes(
+      description = "count at PipelineJob.scala:42",
+      details     = "org.apache.spark.sql.Dataset.count(Dataset.scala:3125)",
+      plan        = "== Physical Plan ==\n*(1) HashAggregate(keys=[], functions=[count(1)])",
+    )
+    assertEquals(attrs.get(Sql.ExecutionId).longValue(), 7L)
+    assertEquals(attrs.get(Sql.Description), "count at PipelineJob.scala:42")
+    assertEquals(attrs.get(Sql.Details), "org.apache.spark.sql.Dataset.count(Dataset.scala:3125)")
+    assertEquals(
+      attrs.get(Sql.Plan),
+      "== Physical Plan ==\n*(1) HashAggregate(keys=[], functions=[count(1)])",
+    )
+    // A plan that fits must not claim to be truncated.
+    assertEquals(attrs.get(Sql.PlanTruncated), null)
+  }
+
+  test("empty and null SQL strings are omitted, not exported as empty attributes") {
+    val attrs = sqlAttributes(description = "", details = null, plan = null)
+    assertEquals(attrs.get(Sql.Description), null)
+    assertEquals(attrs.get(Sql.Details), null)
+    assertEquals(attrs.get(Sql.Plan), null)
+    assertEquals(attrs.get(Sql.PlanTruncated), null)
+    // The execution id is always meaningful, even when Spark supplies no strings at all.
+    assertEquals(attrs.get(Sql.ExecutionId).longValue(), 7L)
+  }
+
+  test("an oversized physical plan is truncated and flagged as such") {
+    val attrs = sqlAttributes(plan = "X" * (TracingSparkListener.MaxPlanChars + 500))
+    assertEquals(attrs.get(Sql.Plan).length, TracingSparkListener.MaxPlanChars)
+    assertEquals(attrs.get(Sql.PlanTruncated).booleanValue(), true)
+  }
+
+  test("a physical plan exactly at the cap is kept whole and not flagged") {
+    val attrs = sqlAttributes(plan = "X" * TracingSparkListener.MaxPlanChars)
+    assertEquals(attrs.get(Sql.Plan).length, TracingSparkListener.MaxPlanChars)
+    assertEquals(attrs.get(Sql.PlanTruncated), null)
+  }
+
+  test("description and details are capped independently of the plan") {
+    val attrs = sqlAttributes(
+      description = "d" * (TracingSparkListener.MaxDescriptionChars + 100),
+      details     = "s" * (TracingSparkListener.MaxDetailsChars + 100),
+    )
+    assertEquals(attrs.get(Sql.Description).length, TracingSparkListener.MaxDescriptionChars)
+    assertEquals(attrs.get(Sql.Details).length, TracingSparkListener.MaxDetailsChars)
   }
 
   test("non-SQL job is parented under app span") {

--- a/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
+++ b/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
@@ -377,10 +377,11 @@ class TracingSparkListenerTest extends FunSuite {
    * this logic covered on every version we build.
    */
   def sqlAttributes(
-    description: String = "",
-    details:     String = "",
-    plan:        String = "",
-    executionId: Long   = 7L,
+    description: String       = "",
+    details:     String       = "",
+    plan:        String       = "",
+    executionId: Long         = 7L,
+    sqlConfig:   FlareConfig  = config,
   ): Attributes = {
     val exporter = InMemorySpanExporter.create()
     val provider = SdkTracerProvider.builder()
@@ -388,7 +389,7 @@ class TracingSparkListenerTest extends FunSuite {
       .build()
     try {
       val tracer   = provider.get("io.flare.spark.test")
-      val listener = new TracingSparkListener(tracer, config, throwOnError = true)
+      val listener = new TracingSparkListener(tracer, sqlConfig, throwOnError = true)
       val span     = tracer.spanBuilder(s"spark.sql.$executionId").startSpan()
       listener.describeSqlExecution(span, executionId, description, details, plan)
       span.end()
@@ -424,24 +425,61 @@ class TracingSparkListenerTest extends FunSuite {
   }
 
   test("an oversized physical plan is truncated and flagged as such") {
-    val attrs = sqlAttributes(plan = "X" * (TracingSparkListener.MaxPlanChars + 500))
-    assertEquals(attrs.get(Sql.Plan).length, TracingSparkListener.MaxPlanChars)
+    val attrs = sqlAttributes(plan = "X" * (config.sqlPlanMaxChars + 500))
+    assertEquals(attrs.get(Sql.Plan).length, config.sqlPlanMaxChars)
     assertEquals(attrs.get(Sql.PlanTruncated).booleanValue(), true)
   }
 
   test("a physical plan exactly at the cap is kept whole and not flagged") {
-    val attrs = sqlAttributes(plan = "X" * TracingSparkListener.MaxPlanChars)
-    assertEquals(attrs.get(Sql.Plan).length, TracingSparkListener.MaxPlanChars)
+    val attrs = sqlAttributes(plan = "X" * config.sqlPlanMaxChars)
+    assertEquals(attrs.get(Sql.Plan).length, config.sqlPlanMaxChars)
     assertEquals(attrs.get(Sql.PlanTruncated), null)
   }
 
   test("description and details are capped independently of the plan") {
     val attrs = sqlAttributes(
-      description = "d" * (TracingSparkListener.MaxDescriptionChars + 100),
-      details     = "s" * (TracingSparkListener.MaxDetailsChars + 100),
+      description = "d" * (config.sqlDescriptionMaxChars + 100),
+      details     = "s" * (config.sqlDetailsMaxChars + 100),
     )
-    assertEquals(attrs.get(Sql.Description).length, TracingSparkListener.MaxDescriptionChars)
-    assertEquals(attrs.get(Sql.Details).length, TracingSparkListener.MaxDetailsChars)
+    assertEquals(attrs.get(Sql.Description).length, config.sqlDescriptionMaxChars)
+    assertEquals(attrs.get(Sql.Details).length, config.sqlDetailsMaxChars)
+  }
+
+  test("configured caps override the defaults") {
+    val attrs = sqlAttributes(
+      description = "d" * 100,
+      details     = "s" * 100,
+      plan        = "X" * 100,
+      sqlConfig   = config.copy(
+        sqlPlanMaxChars        = 10,
+        sqlDetailsMaxChars     = 20,
+        sqlDescriptionMaxChars = 30,
+      ),
+    )
+    assertEquals(attrs.get(Sql.Plan).length, 10)
+    assertEquals(attrs.get(Sql.Details).length, 20)
+    assertEquals(attrs.get(Sql.Description).length, 30)
+    assertEquals(attrs.get(Sql.PlanTruncated).booleanValue(), true)
+  }
+
+  test("a cap of 0 drops the attribute rather than exporting an empty string") {
+    val attrs = sqlAttributes(
+      description = "d" * 100,
+      details     = "s" * 100,
+      plan        = "X" * 100,
+      sqlConfig   = config.copy(
+        sqlPlanMaxChars        = 0,
+        sqlDetailsMaxChars     = 0,
+        sqlDescriptionMaxChars = 0,
+      ),
+    )
+    assertEquals(attrs.get(Sql.Plan), null)
+    assertEquals(attrs.get(Sql.Details), null)
+    assertEquals(attrs.get(Sql.Description), null)
+    // No plan attribute means nothing to flag as truncated.
+    assertEquals(attrs.get(Sql.PlanTruncated), null)
+    // The execution id is never suppressed.
+    assertEquals(attrs.get(Sql.ExecutionId).longValue(), 7L)
   }
 
   test("non-SQL job is parented under app span") {


### PR DESCRIPTION
Closes #44

## Summary

The `spark.sql.N` span was created with **no attributes at all**, making a SQL execution
unidentifiable in a trace — despite Spark handing us the description, callsite and formatted
physical plan for free on `SparkListenerSQLExecutionStart`.

Now recorded: `spark.sql.execution.id`, `spark.sql.description`, `spark.sql.details`,
`spark.sql.plan`, and `spark.sql.plan.truncated`.

`spark.sql.description` is worth calling out — it is Spark's own query label
(`count at PipelineJob.scala:43`), which identifies a query far better than the stage names
derived from `RDD.creationSite` that prompted #48.

This is the cheap half of the SQL gap. Per-operator metrics from `sparkPlanInfo` are **not**
here and remain in #47.

## Two decisions worth reviewing

**Fields are read by name, never positionally.** I checked the constructor across the matrix
with `javap` rather than assuming:

| Spark | `apply` signature |
|---|---|
| 3.3.4 | `(executionId, description, details, physicalPlanDescription, sparkPlanInfo, time, modifiedConfigs)` |
| 3.4.3 | `(executionId, `**`rootExecutionId`**`, description, …, modifiedConfigs)` |
| 4.0.0 | `(executionId, rootExecutionId, description, …, modifiedConfigs, `**`jobTags`**`, `**`jobGroupId`**`)` |

`rootExecutionId` is inserted *second* in 3.4, and has no default. So a positional fixture that
compiles on 3.5 fails to compile on 3.3. That is why the logic lives in `describeSqlExecution`,
which takes loose values: it is directly testable on every version we build, without constructing
a Spark event at all. The trade-off is that the four-line field access in `onSQLStart` is covered
by the dev-stack run below rather than by a unit test — deliberate, and documented in the code.

**The strings are capped, and truncation is flagged.** They are unbounded at the source, and one
oversized attribute can push an OTLP batch past a collector's message limit — which drops the
entire batch, not just the plan. Caps are plan 4096 / details 2048 / description 1024. A clipped
plan sets `spark.sql.plan.truncated=true`, because a silently clipped plan reads exactly like a
complete one to whoever is diagnosing a slow join.

The plan cap is deliberately much larger than the 500 used for `Stage.FailureReason`: a failure
reason is readable in its first line, a plan truncated to 500 chars loses every operator that
matters. Real plans from PipelineJob measured 1.5–3.8 KB, so 4096 fits them without truncating —
but not by a wide margin, and a more complex query will exceed it. That is expected, and what the
flag is for.

## Test plan

- [x] `sbt -DsparkVersion=3.5.1 ++2.13.16 test` — 105 passed (was 100)
- [x] `sbt -DsparkVersion=3.5.1 ++2.12.18 test` — 105 passed
- [x] `Test / compile` against Spark 3.3.4, 3.4.3 and 4.0.0 on 2.13.16 — all green, confirming
      the by-name access survives the constructor changes above
- [x] Five new unit tests: attributes populated; empty/null omitted rather than exported empty;
      oversized plan truncated *and* flagged; plan exactly at the cap kept whole and *not*
      flagged; description/details capped independently
- [x] End-to-end in the dev stack — PipelineJob emitted 3 SQL spans, each carrying the plan:

```
=== spark.sql.0
   spark.sql.description   count at PipelineJob.scala:43
   spark.sql.execution.id  0
   spark.sql.plan          == Physical Plan == | AdaptiveSparkPlan (9) | +- HashAggregate (8)
                           | +- Exchange (7) | +- HashAggregate (6) | +- InMemoryTableScan (1) ...
```

`spark.sql.plan.truncated` correctly absent on all three.

## Noticed, not fixed

Alloy is dropping metric batches in the dev stack: Mimir rejects `target_info` because the
OTel-standard `process.command.args` resource attribute exceeds its label-value length limit
(`err-mimir-label-value-too-long`, `dropped_items=40`). Unrelated to this change and pre-existing.
Happy to file it separately.