### PR TITLE
Measure every task, and drop the exemplar when the span is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of `flare-spark-assembly-${FLARE_VERSION}.jar`; removed `FLARE_VERSION` build arg
 
 ### Fixed
+- **`FLARE_SLOW_TASK_MS` now actually suppresses spans** — it never has. The abandon path in
+  `FlareExecutorPlugin.endTask` ended with a `return` from inside a closure passed to `foreach`,
+  which in Scala compiles to a thrown `NonLocalReturnControl`. The enclosing `try`'s `finally`
+  therefore still ran and called `span.end()`, exporting the very span the filter had just
+  decided to drop. Tasks below the threshold were exported exactly as if the filter were unset,
+  with no error to indicate it. Two knock-on effects went with it: `scope.close()` ran twice, and
+  `spanCount.decrementAndGet()` released a `FLARE_MAX_SPANS_PER_TRACE` slot for a span that was
+  in fact exported, so the circuit breaker admitted more spans than its configured limit.
+  Verified against the dev stack: with `FLARE_SLOW_TASK_MS=500`, the same job dropped from 13
+  exported task spans to 2, the only two that exceeded the threshold ([#57])
 - **Task metrics are no longer dropped when the task span is suppressed** — every guard in
   `FlareExecutorPlugin.onTaskStart()` (granularity, sampling, stage filters, and the
   `FLARE_MAX_SPANS_PER_TRACE` circuit breaker) returned before any measurement state was armed,
@@ -110,6 +120,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Agent test port collision** — the reserved OTLP collector port is released before the test
   JVM forks, so the stub collector now retries the bind and reports the real cause rather than
   surfacing a bare `BindException` ([#42])
+- **Dev stack: Mimir now stores exemplars** — `limits.max_global_exemplars_per_user` defaults to
+  `0`, meaning disabled, so every exemplar the SDK attached was accepted over OTLP and silently
+  discarded. The rest of the chain was correct — the executor plugin records inside the span
+  scope, the Mimir datasource declares `exemplarTraceIdDestinations`, the dashboard panel sets
+  `"exemplar": true` — so the only symptom was a panel with no exemplar dots, which is
+  indistinguishable from having no traffic ([#58])
 
 ### Documentation
 - **Resource attributes** — README documents `flare.role` and `flare.version`, how the role is
@@ -203,3 +219,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#47]: https://github.com/Neutrinic/flare/issues/47
 [#52]: https://github.com/Neutrinic/flare/issues/52
 [#53]: https://github.com/Neutrinic/flare/issues/53
+[#57]: https://github.com/Neutrinic/flare/issues/57
+[#58]: https://github.com/Neutrinic/flare/issues/58

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of `flare-spark-assembly-${FLARE_VERSION}.jar`; removed `FLARE_VERSION` build arg
 
 ### Fixed
+- **Task metrics are no longer dropped when the task span is suppressed** — every guard in
+  `FlareExecutorPlugin.onTaskStart()` (granularity, sampling, stage filters, and the
+  `FLARE_MAX_SPANS_PER_TRACE` circuit breaker) returned before any measurement state was armed,
+  so `flare.task.duration` and the shuffle counters saw nothing for those tasks. On a job that
+  tripped the breaker, or at the default `stages` granularity, the task histogram was empty or
+  badly undercounted — and a drop caused by span filtering read as a drop in cluster throughput.
+  Metric state is now armed independently of the span, so a suppressed span still yields a
+  measurement ([#53])
+- **Dangling exemplars on tail-filtered tasks** — a task suppressed by `FLARE_SLOW_TASK_MS` has
+  its span abandoned rather than ended, so it is never exported. Its metric was nonetheless
+  recorded while the span scope was still current, and the SDK's default `trace_based` exemplar
+  filter stamped the data point with that span's ID. Clicking the exemplar in Grafana opened a
+  trace that does not exist. The scope is now closed before recording in that path ([#52])
 - **Agent resource attributes** — register the Java
   `AutoConfigurationCustomizerProvider` through ServiceLoader so `flare.role` and
   `flare.version` are emitted. Version metadata now comes from an sbt-generated classpath
@@ -188,3 +201,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#42]: https://github.com/Neutrinic/flare/issues/42
 [#44]: https://github.com/Neutrinic/flare/issues/44
 [#47]: https://github.com/Neutrinic/flare/issues/47
+[#52]: https://github.com/Neutrinic/flare/issues/52
+[#53]: https://github.com/Neutrinic/flare/issues/53

--- a/docker/mimir-config.yaml
+++ b/docker/mimir-config.yaml
@@ -44,3 +44,8 @@ store_gateway:
 
 limits:
   native_histograms_ingestion_enabled: true
+  # Exemplar storage is OFF by default in Mimir (0 = disabled). Without this, the exemplars the
+  # OTEL SDK attaches to flare.task.duration are accepted at ingest and silently discarded, so
+  # the dashboard's "exemplar": true and the Mimir datasource's exemplarTraceIdDestinations
+  # have nothing to render and the trace/metric correlation looks broken end to end.
+  max_global_exemplars_per_user: 100000

--- a/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
+++ b/src/main/scala/io/flare/spark/plugin/FlareExecutorPlugin.scala
@@ -45,14 +45,17 @@ class FlareExecutorPlugin extends ExecutorPlugin {
   // Set to true once the maxSpansPerTrace warning has been logged, to avoid log spam
   @volatile private var maxSpansWarned = false
 
-  // ThreadLocal holds the active (span, scope, taskContext) for the current task on this thread.
-  // None means this task was not sampled or granularity suppressed it.
+  // Span state for the current task on this thread. None means a filter suppressed the span.
+  private val taskState = new ThreadLocal[Option[(Span, Scope)]]()
+
+  // Metric state for the current task on this thread: the captured TaskContext and the start
+  // timestamp. Deliberately independent of taskState — metrics are pre-aggregated, so the
+  // cardinality pressure that justifies dropping spans does not apply to them, and a task whose
+  // span is suppressed must still be measured.
+  //
   // TaskContext is captured at onTaskStart because Spark 4.0 clears TaskContext.get() before
   // onTaskSucceeded/onTaskFailed fires, so we can't rely on it in endTask.
-  private val taskState = new ThreadLocal[Option[(Span, Scope, TaskContext)]]()
-
-  // Nanosecond timestamp at task start — used for duration_ms attribute and slow task filter.
-  private val taskStartNanos = new ThreadLocal[Long]()
+  private val taskMetricState = new ThreadLocal[Option[(TaskContext, Long)]]()
 
   override def init(ctx: PluginContext, extraConf: ju.Map[String, String]): Unit = {
     config = try FlareConfig.load() catch {
@@ -80,12 +83,21 @@ class FlareExecutorPlugin extends ExecutorPlugin {
   }
 
   override def onTaskStart(): Unit = {
+    // Clear both up front so a task can never inherit state from the previous task that ran
+    // on this thread, whatever path the rest of this method takes.
+    taskState.set(None)
+    taskMetricState.set(None)
+
     val taskContext = TaskContext.get()
     if (taskContext == null) {
+      // Nothing to attribute a span or a measurement to. The only guard that suppresses both.
       logger.warn("[Flare] onTaskStart called with null TaskContext")
-      taskState.set(None)
       return
     }
+
+    // Armed before the span guards, so every task Spark hands us is measured even when its
+    // span is filtered out below.
+    taskMetricState.set(Some((taskContext, System.nanoTime())))
 
     // Guard 1: granularity + stage/retry filters (replaces simple tracesTasks check).
     // slowTaskMs is deferred to endTask since duration is not known at start.
@@ -96,10 +108,7 @@ class FlareExecutorPlugin extends ExecutorPlugin {
                              // handles them. True speculative detection needs Phase 2 ByteBuddy.
       stageId       = taskContext.stageId(),
       stageName     = "",    // stage name not available on executor until Phase 2
-    )) {
-      taskState.set(None)
-      return
-    }
+    )) return
 
     val parentContext = LocalPropertyPropagator.extract(taskContext)
 
@@ -111,7 +120,6 @@ class FlareExecutorPlugin extends ExecutorPlugin {
     val parentSpanContext = io.opentelemetry.api.trace.Span.fromContext(parentContext).getSpanContext
     if (parentSpanContext.isValid && !parentSpanContext.isSampled) {
       logger.debug(s"[Flare] Task not sampled (inherited from driver), partition=${taskContext.partitionId()}")
-      taskState.set(None)
       return
     }
 
@@ -119,10 +127,10 @@ class FlareExecutorPlugin extends ExecutorPlugin {
     if (spanCount.get() >= config.maxSpansPerTrace) {
       if (!maxSpansWarned) {
         logger.warn(s"[Flare] Executor span limit reached (${config.maxSpansPerTrace}). " +
-          s"Suppressing further task spans. Increase FLARE_MAX_SPANS_PER_TRACE to raise the limit.")
+          s"Suppressing further task spans. Task metrics continue to be recorded. " +
+          s"Increase FLARE_MAX_SPANS_PER_TRACE to raise the limit.")
         maxSpansWarned = true
       }
-      taskState.set(None)
       return
     }
     val currentCount = spanCount.incrementAndGet()
@@ -143,8 +151,7 @@ class FlareExecutorPlugin extends ExecutorPlugin {
 
     val span  = spanBuilder.startSpan()
     val scope = span.makeCurrent()
-    taskState.set(Some((span, scope, taskContext)))
-    taskStartNanos.set(System.nanoTime())
+    taskState.set(Some((span, scope)))
 
     // MDC enrichment — inject trace_id/span_id into Log4j 2 ThreadContext for log correlation
     MdcEnricher.put(span.getSpanContext.getTraceId, span.getSpanContext.getSpanId)
@@ -159,80 +166,105 @@ class FlareExecutorPlugin extends ExecutorPlugin {
     endTask(success = false, reason = Some(failureReason.toString))
 
   private def endTask(success: Boolean, reason: Option[String]): Unit = {
-    Option(taskState.get()).flatten.foreach { case (span, scope, capturedTaskContext) =>
-      try {
-        // Compute duration for slow task filter and duration attribute
-        val startNanos = taskStartNanos.get()
-        val durationMs = if (startNanos > 0) (System.nanoTime() - startNanos) / 1000000L else -1L
+    val metricState = Option(taskMetricState.get()).flatten
+    val durationMs  = metricState
+      .map { case (_, startNanos) => (System.nanoTime() - startNanos) / 1000000L }
+      .getOrElse(-1L)
 
-        // Slow task filter — drop span if task was faster than threshold.
-        // We cannot avoid starting the span (duration unknown at start), so we abandon it here.
-        // Calling span.end() would export a span we want to suppress. Instead we close the scope
-        // and leave the span unended — BatchSpanProcessor only exports ended spans.
+    try {
+      (Option(taskState.get()).flatten, metricState) match {
+        // A span was created and survives the slow-task filter: describe it, then record
+        // metrics while the scope is still open so the SDK attaches an exemplar pointing at
+        // a span that really will be exported.
+        case (Some((span, scope)), Some((tc, _))) if !isSuppressedAsFast(durationMs) =>
+          try {
+            describeTaskSpan(span, tc, durationMs, success, reason)
+            recordTaskMetrics(tc, durationMs, success)
+          } finally {
+            MdcEnricher.remove()
+            scope.close()
+            span.end()
+          }
+
+        // A span was created but the task finished under FLARE_SLOW_TASK_MS, so the span is
+        // abandoned rather than ended. We cannot avoid starting it — duration is unknown at
+        // task start — and calling span.end() would export exactly what we mean to suppress.
+        // BatchSpanProcessor only exports ended spans, so leaving it unended drops it.
+        //
+        // Ordering is load-bearing: the scope must be closed BEFORE the metric is recorded.
+        // The SDK's default exemplar filter is trace_based, which reads Span.current() at
+        // record time. Recording inside the scope would stamp the data point with the trace
+        // and span id of a span that is never exported, leaving a dashboard exemplar that
+        // links to nothing.
+        //
         // Tradeoff: the SDK's internal SdkSpan object remains allocated until GC reclaims it.
-        // On jobs with many fast tasks (e.g. thousands below threshold) this is transient memory
-        // pressure proportional to concurrent executor threads, not total tasks — each ThreadLocal
-        // is overwritten on the next task. Acceptable for the filtering benefit.
-        if (config.slowTaskMs > 0 && durationMs >= 0 && durationMs < config.slowTaskMs) {
-          // Record metrics even for fast tasks whose spans are dropped — metrics have
-          // their own aggregation and don't suffer from span cardinality pressure.
-          recordTaskMetrics(capturedTaskContext, durationMs, success)
+        // On jobs with many fast tasks this is transient memory pressure proportional to
+        // concurrent executor threads, not total tasks. Acceptable for the filtering benefit.
+        case (Some((span, scope)), Some((tc, _))) =>
           MdcEnricher.remove()
           scope.close()
           spanCount.decrementAndGet() // reclaim slot — this span won't be exported
-          taskState.remove()
-          taskStartNanos.remove()
-          return
-        }
+          recordTaskMetrics(tc, durationMs, success)
 
-        // Set status
-        if (success) {
-          span.setStatus(StatusCode.OK)
-          span.setAttribute(Task.Result, "SUCCESS")
-        } else {
-          span.setStatus(StatusCode.ERROR, reason.getOrElse("Task failed"))
-          span.setAttribute(Task.Result, "FAILED")
-          reason.foreach(r => span.setAttribute(Error.Message, r))
-        }
+        // No span: a guard in onTaskStart suppressed it. The task still ran and is still
+        // measured — this is the case that keeps the task histogram honest when the
+        // maxSpansPerTrace circuit breaker trips, or when driver sampling excluded the trace.
+        // No scope is open here, so no exemplar is attached, which is correct.
+        case (None, Some((tc, _))) =>
+          recordTaskMetrics(tc, durationMs, success)
 
-        // Record task duration
-        if (durationMs >= 0) {
-          span.setLong(Task.DurationMs, durationMs)
-        }
-
-        // Record task metrics from TaskMetrics (only fully populated at task end).
-        // TaskContext is captured at onTaskStart because Spark 4.0 clears TaskContext.get()
-        // before onTaskSucceeded/onTaskFailed fires (unlike Spark 3.x).
-        try {
-          val m = capturedTaskContext.taskMetrics()
-          span.setLong(Task.ShuffleReadBytes, m.shuffleReadMetrics.totalBytesRead)
-          span.setLong(Task.ShuffleWriteBytes, m.shuffleWriteMetrics.bytesWritten)
-          span.setLong(Task.PeakMemory, m.peakExecutionMemory)
-          span.setLong(Task.InputBytes, m.inputMetrics.bytesRead)
-          span.setLong(Task.OutputBytes, m.outputMetrics.bytesWritten)
-        } catch {
-          // TaskMetrics is private[spark] — may throw IllegalAccessError from outside
-          // org.apache.spark, or fail in barrier mode. Log once for diagnosis.
-          case e: Throwable =>
-            logger.debug(s"[Flare] Could not read TaskMetrics: ${e.getClass.getSimpleName}: ${e.getMessage}")
-        }
-
-        // SQL execution ID from local properties (captured context still has properties)
-        Option(capturedTaskContext.getLocalProperty("spark.sql.execution.id"))
-          .flatMap(s => scala.util.Try(s.toLong).toOption)
-          .foreach(id => span.setLong(Task.SqlExecutionId, id))
-
-        // Record OTEL metrics while span scope is still active → automatic exemplar linking.
-        // The SDK captures the current span's trace ID + span ID on each data point.
-        recordTaskMetrics(capturedTaskContext, durationMs, success)
-      } finally {
-        MdcEnricher.remove()
-        scope.close()
-        span.end()
-        taskState.remove()
-        taskStartNanos.remove()
+        // No TaskContext was available at task start. Nothing to record.
+        case _ => ()
       }
+    } finally {
+      taskState.remove()
+      taskMetricState.remove()
     }
+  }
+
+  /** True when FLARE_SLOW_TASK_MS is active and this task finished under the threshold. */
+  private def isSuppressedAsFast(durationMs: Long): Boolean =
+    config.slowTaskMs > 0 && durationMs >= 0 && durationMs < config.slowTaskMs
+
+  private def describeTaskSpan(
+    span:       Span,
+    tc:         TaskContext,
+    durationMs: Long,
+    success:    Boolean,
+    reason:     Option[String],
+  ): Unit = {
+    if (success) {
+      span.setStatus(StatusCode.OK)
+      span.setAttribute(Task.Result, "SUCCESS")
+    } else {
+      span.setStatus(StatusCode.ERROR, reason.getOrElse("Task failed"))
+      span.setAttribute(Task.Result, "FAILED")
+      reason.foreach(r => span.setAttribute(Error.Message, r))
+    }
+
+    if (durationMs >= 0) {
+      span.setLong(Task.DurationMs, durationMs)
+    }
+
+    // Task metrics from TaskMetrics (only fully populated at task end).
+    try {
+      val m = tc.taskMetrics()
+      span.setLong(Task.ShuffleReadBytes, m.shuffleReadMetrics.totalBytesRead)
+      span.setLong(Task.ShuffleWriteBytes, m.shuffleWriteMetrics.bytesWritten)
+      span.setLong(Task.PeakMemory, m.peakExecutionMemory)
+      span.setLong(Task.InputBytes, m.inputMetrics.bytesRead)
+      span.setLong(Task.OutputBytes, m.outputMetrics.bytesWritten)
+    } catch {
+      // TaskMetrics is private[spark] — may throw IllegalAccessError from outside
+      // org.apache.spark, or fail in barrier mode. Log once for diagnosis.
+      case e: Throwable =>
+        logger.debug(s"[Flare] Could not read TaskMetrics: ${e.getClass.getSimpleName}: ${e.getMessage}")
+    }
+
+    // SQL execution ID from local properties (captured context still has properties)
+    Option(tc.getLocalProperty("spark.sql.execution.id"))
+      .flatMap(s => scala.util.Try(s.toLong).toOption)
+      .foreach(id => span.setLong(Task.SqlExecutionId, id))
   }
 
   private def recordTaskMetrics(tc: TaskContext, durationMs: Long, success: Boolean): Unit = {
@@ -266,7 +298,7 @@ class FlareExecutorPlugin extends ExecutorPlugin {
     logger.info(s"[Flare] Executor plugin shutdown (total spans created: ${spanCount.get()})")
 
     // End any in-flight task span on this thread (e.g. K8s SIGTERM during task execution)
-    Option(taskState.get()).flatten.foreach { case (span, scope, _) =>
+    Option(taskState.get()).flatten.foreach { case (span, scope) =>
       MdcEnricher.remove()
       span.setStatus(StatusCode.ERROR, "Executor shutdown before task completed")
       span.setAttribute(Task.Result, "SHUTDOWN")
@@ -274,6 +306,7 @@ class FlareExecutorPlugin extends ExecutorPlugin {
       span.end()
       taskState.remove()
     }
+    taskMetricState.remove()
 
     // Force-flush TracerProvider and MeterProvider to push buffered spans/metrics
     // before JVM exits. The SDK classes live in the agent classloader — catch

--- a/src/test/scala/io/flare/spark/plugin/FlareExecutorPluginTest.scala
+++ b/src/test/scala/io/flare/spark/plugin/FlareExecutorPluginTest.scala
@@ -1,0 +1,197 @@
+package io.flare.spark.plugin
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.testing.exporter.{InMemoryMetricReader, InMemorySpanExporter}
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
+import munit.FunSuite
+import org.apache.spark.FlareTestHelpers
+import org.apache.spark.api.plugin.PluginContext
+
+import scala.collection.JavaConverters._
+
+/**
+ * Covers the interaction between task span suppression and task metric recording.
+ *
+ * Two rules are asserted here, and they pull in opposite directions:
+ *   1. A task whose span is suppressed must still be measured. Metrics are pre-aggregated,
+ *      so the cardinality pressure that justifies dropping spans does not apply to them.
+ *   2. A metric recorded for a suppressed task must NOT carry an exemplar, because an
+ *      exemplar names a span that will never reach the backend.
+ */
+class FlareExecutorPluginTest extends FunSuite {
+
+  private val flareProps = List(
+    "FLARE_TRACE_GRANULARITY", "FLARE_SLOW_TASK_MS", "FLARE_MAX_SPANS_PER_TRACE",
+    "FLARE_SAMPLING_RATIO", "FLARE_METRICS_ENABLED",
+  )
+
+  override def afterEach(context: AfterEach): Unit = {
+    flareProps.foreach(sys.props.remove)
+    FlareTestHelpers.unbindTaskContext()
+    GlobalOpenTelemetry.resetForTest()
+    super.afterEach(context)
+  }
+
+  private object StubPluginContext extends PluginContext {
+    override def metricRegistry(): com.codahale.metrics.MetricRegistry = null
+    override def conf(): org.apache.spark.SparkConf                    = new org.apache.spark.SparkConf()
+    override def executorID(): String                                  = "7"
+    override def hostname(): String                                    = "localhost"
+    override def resources(): java.util.Map[String, org.apache.spark.resource.ResourceInformation] =
+      java.util.Collections.emptyMap()
+    override def send(message: Any): Unit  = ()
+    override def ask(message: Any): AnyRef = null
+  }
+
+  /** Result of driving `taskCount` tasks through a freshly initialised plugin. */
+  private case class Run(
+    exportedTraceIds: Set[String],
+    durationCount:    Long,
+    exemplarTraceIds: Seq[String],
+  )
+
+  /**
+   * Registers a test SDK as the global OpenTelemetry, runs `taskCount` complete tasks through
+   * a real FlareExecutorPlugin, and reports what was exported.
+   *
+   * The plugin resolves its tracer and meter from GlobalOpenTelemetry, so the SDK has to be
+   * registered before init().
+   */
+  private def runTasks(taskCount: Int = 1, succeed: Boolean = true): Run = {
+    val spanExporter = InMemorySpanExporter.create()
+    val metricReader = InMemoryMetricReader.create()
+
+    val sdk = OpenTelemetrySdk.builder()
+      .setTracerProvider(
+        SdkTracerProvider.builder()
+          .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+          .build()
+      )
+      .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+      .buildAndRegisterGlobal()
+
+    try {
+      val plugin = new FlareExecutorPlugin()
+      plugin.init(StubPluginContext, java.util.Collections.emptyMap[String, String]())
+
+      (1 to taskCount).foreach { _ =>
+        FlareTestHelpers.bindEmptyTaskContext()
+        plugin.onTaskStart()
+        if (succeed) plugin.onTaskSucceeded()
+        else plugin.onTaskFailed(org.apache.spark.TaskResultLost)
+        FlareTestHelpers.unbindTaskContext()
+      }
+
+      val exported = spanExporter.getFinishedSpanItems.asScala
+        .map(_.getSpanContext.getTraceId)
+        .toSet
+
+      val durationPoints = metricReader.collectAllMetrics().asScala
+        .filter(_.getName == "flare.task.duration")
+        .flatMap(_.getHistogramData.getPoints.asScala)
+
+      Run(
+        exportedTraceIds = exported,
+        durationCount    = durationPoints.map(_.getCount).sum,
+        exemplarTraceIds = durationPoints
+          .flatMap(_.getExemplars.asScala)
+          .map(_.getSpanContext.getTraceId)
+          .toSeq,
+      )
+    } finally sdk.close()
+  }
+
+  // ── Baseline ───────────────────────────────────────────────────────────────
+
+  test("a traced task exports one span and one metric point linked by an exemplar") {
+    sys.props("FLARE_TRACE_GRANULARITY") = "all"
+    val run = runTasks()
+
+    assertEquals(run.exportedTraceIds.size, 1)
+    assertEquals(run.durationCount, 1L)
+    assertEquals(run.exemplarTraceIds.size, 1)
+    // The exemplar must name the span that was actually exported.
+    assertEquals(run.exemplarTraceIds.toSet, run.exportedTraceIds)
+  }
+
+  // ── #52: slow-task suppression must not leave a dangling exemplar ───────────
+
+  test("a task suppressed by FLARE_SLOW_TASK_MS is measured but exports no span") {
+    sys.props("FLARE_TRACE_GRANULARITY") = "all"
+    // Far above any plausible duration for an empty task, so every task is suppressed.
+    sys.props("FLARE_SLOW_TASK_MS") = "600000"
+    val run = runTasks()
+
+    assertEquals(run.exportedTraceIds, Set.empty[String])
+    // The metric survives — this is the stated rationale for the suppression path.
+    assertEquals(run.durationCount, 1L)
+  }
+
+  test("a metric for a slow-task-suppressed span carries no exemplar") {
+    sys.props("FLARE_TRACE_GRANULARITY") = "all"
+    sys.props("FLARE_SLOW_TASK_MS") = "600000"
+    val run = runTasks()
+
+    // The span is abandoned unended and never exported. An exemplar naming it would send
+    // anyone who clicked it in Grafana to a trace that does not exist.
+    assertEquals(run.exemplarTraceIds, Seq.empty[String])
+  }
+
+  // ── #53: guards in onTaskStart must not suppress metrics ───────────────────
+
+  test("tasks suppressed by the maxSpansPerTrace circuit breaker are still measured") {
+    sys.props("FLARE_TRACE_GRANULARITY")   = "all"
+    sys.props("FLARE_MAX_SPANS_PER_TRACE") = "1"
+    val run = runTasks(taskCount = 4)
+
+    // The breaker caps spans at 1 ...
+    assertEquals(run.exportedTraceIds.size, 1)
+    // ... but the task histogram must still see all 4, or the throughput drop caused by the
+    // limiter reads as a drop in cluster throughput.
+    assertEquals(run.durationCount, 4L)
+  }
+
+  test("tasks suppressed by granularity are still measured") {
+    // Stages granularity means no task spans at all.
+    sys.props("FLARE_TRACE_GRANULARITY") = "stages"
+    val run = runTasks(taskCount = 3)
+
+    assertEquals(run.exportedTraceIds, Set.empty[String])
+    assertEquals(run.durationCount, 3L)
+  }
+
+  test("a failed task is measured even when its span is suppressed") {
+    sys.props("FLARE_TRACE_GRANULARITY") = "stages"
+    val run = runTasks(taskCount = 2, succeed = false)
+
+    assertEquals(run.exportedTraceIds, Set.empty[String])
+    assertEquals(run.durationCount, 2L)
+  }
+
+  // ── The invariant, stated once ─────────────────────────────────────────────
+
+  test("every task is measured and every exemplar names an exported span, in every mode") {
+    val modes = List(
+      Map("FLARE_TRACE_GRANULARITY" -> "all"),
+      Map("FLARE_TRACE_GRANULARITY" -> "all", "FLARE_SLOW_TASK_MS" -> "600000"),
+      Map("FLARE_TRACE_GRANULARITY" -> "all", "FLARE_MAX_SPANS_PER_TRACE" -> "1"),
+      Map("FLARE_TRACE_GRANULARITY" -> "stages"),
+    )
+
+    modes.foreach { mode =>
+      flareProps.foreach(sys.props.remove)
+      mode.foreach { case (k, v) => sys.props(k) = v }
+      val run = runTasks(taskCount = 3)
+      GlobalOpenTelemetry.resetForTest()
+
+      // Suppressing a span never suppresses its measurement.
+      assertEquals(run.durationCount, 3L, s"tasks went unmeasured under $mode")
+
+      val dangling = run.exemplarTraceIds.toSet -- run.exportedTraceIds
+      assertEquals(dangling, Set.empty[String], s"dangling exemplars under $mode")
+    }
+  }
+}

--- a/src/test/scala/org/apache/spark/FlareTestHelpers.scala
+++ b/src/test/scala/org/apache/spark/FlareTestHelpers.scala
@@ -11,6 +11,20 @@ object FlareTestHelpers {
 
   def emptyTaskMetrics(): TaskMetrics = new TaskMetrics()
 
+  /**
+   * A real, empty TaskContext bound to the calling thread.
+   *
+   * `TaskContext.empty()` is private[spark] but its signature is identical across 3.3-4.0,
+   * unlike the TaskContextImpl constructor, so this stays compilable on the whole matrix.
+   */
+  def bindEmptyTaskContext(): TaskContext = {
+    val tc = TaskContext.empty()
+    TaskContext.setTaskContext(tc)
+    tc
+  }
+
+  def unbindTaskContext(): Unit = TaskContext.unset()
+
   def jobFailed(exception: Exception): JobResult = JobFailed(exception)
 
   def makeStageInfo(


### PR DESCRIPTION
Closes #52
Closes #53
Closes #57
Closes #58

## Summary

`FlareExecutorPlugin` kept span state and metric state in a single `ThreadLocal`, and drove the suppression path with an early `return` out of a closure. Three defects fell out of that, all in `endTask`.

**#57 — `FLARE_SLOW_TASK_MS` never suppressed a span.** The abandon branch ended with `return` from inside a lambda passed to `foreach`. In Scala that compiles to a thrown `NonLocalReturnControl`, so the enclosing `try`'s `finally` still ran and called `span.end()` — exporting the span the filter had just decided to drop. Tail-based straggler retention, shipped and documented in v1.0.0, was inert. Knock-on: `scope.close()` ran twice, and `spanCount.decrementAndGet()` released a `FLARE_MAX_SPANS_PER_TRACE` slot for a span that *was* exported, so the breaker admitted more than its limit.

**#53 — task metrics dropped whenever the span was.** All four guards in `onTaskStart` (null `TaskContext`, `shouldTraceTask`, sampling, breaker) set `taskState.set(None)` and returned, and `endTask` then recorded nothing. At the default `stages` granularity the task histogram was empty; when the breaker tripped, the drop in `flare.task.duration` read as a collapse in cluster throughput rather than span filtering working. Metrics are pre-aggregated, so the cardinality pressure that justifies dropping spans does not apply to them.

**#52 — dangling exemplars.** The slow-task path recorded metrics while the abandoned span's scope was still current. The SDK's default `trace_based` exemplar filter reads `Span.current()` at record time, so the data point was stamped with a span that would never be exported. This was latent behind #57 — it only becomes reachable once suppression actually works.

All three come out of one restructure: a `taskMetricState` armed as soon as a `TaskContext` exists, before any span guard, and an `endTask` that matches explicitly over span/metric state instead of returning early. Scope-close ordering is now load-bearing in the abandoned-span path and is commented as such.

**#58 — dev stack discarded all exemplars.** Mimir's `limits.max_global_exemplars_per_user` defaults to `0`. Every exemplar was accepted over OTLP and dropped at ingest, which is why none of this was visible before. The rest of the chain was already correct, so the only symptom was a panel with no dots.

## Behaviour change

Spans that were previously exported despite `FLARE_SLOW_TASK_MS` are now correctly suppressed — a **reduction** in span volume for anyone who had set it. No change to span shape, attributes, or metric names. Tasks that previously produced no data point now produce one.

## Verification

Live, against the dev LGTM stack. Same `PipelineJob`, `FLARE_SLOW_TASK_MS=500` on the executor JVM (confirmed present in the worker's executor launch command); only the jar differs.

| | task spans in Tempo | task span durations (ms) | exemplars | tasks measured |
|---|---|---|---|---|
| pre-fix | 13 | 129, 141, 146, 274, 274, 285, 286, 317, 318, 363, 363, 1021, 1021 | 8 | 13 |
| fixed | 2 | 1028, 1028 | 1 | 13 |

The single exemplar from the fixed run names span `ccf4d5b07c7b256e`, confirmed present in Tempo — a live link, not a dead one.

## Test plan
- [x] New `FlareExecutorPluginTest` — 7 tests driving a real plugin against `InMemorySpanExporter` + `InMemoryMetricReader`, covering each suppression mode plus a cross-mode invariant (every task measured, every exemplar names an exported span)
- [x] Tests verified to fail on the pre-fix implementation: reverting `FlareExecutorPlugin.scala` alone gives 5 failures, all on the #52/#53/#57 assertions
- [x] `sbt -DsparkVersion=3.5.1 ++2.13.16 test` — 117 passed
- [x] `sbt -DsparkVersion=3.5.1 ++2.12.18 test` — 117 passed
- [x] `Test / compile` on Spark 3.3.4, 3.4.3, 4.0.0 (Scala 2.13.16)
- [x] End-to-end in the dev stack, table above
- [ ] CI matrix