### PR TITLE
Record the post-AQE plan on spark.sql.plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **SQL execution metadata on `spark.sql.N` spans** — the span previously carried no attributes
   at all. It now records `spark.sql.execution.id`, `spark.sql.description`, `spark.sql.details`
-  and `spark.sql.plan` (the formatted physical plan), all sourced from
+  and `spark.sql.plan` (the formatted physical plan that ran, see [#54]), sourced from
   `SparkListenerSQLExecutionStart`. `spark.sql.description` is Spark's own query label, e.g.
   `count at PipelineJob.scala:43`, which identifies a query far better than the stage names
   derived from `RDD.creationSite`.
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clipped plan sets `spark.sql.plan.truncated=true`, so a partial plan is never mistaken for a
   complete one. Empty or absent values are omitted rather than exported as empty attributes.
   Per-operator metrics from `sparkPlanInfo` are not included ([#44], tracked in [#47])
+- **`FLARE_SQL_PLAN_INITIAL_MAX_CHARS`** — retains the pre-AQE plan as `spark.sql.plan.initial`,
+  with its own truncation flag `spark.sql.plan.initial.truncated`. Off by default (`0`) because
+  it doubles the worst-case plan payload on every SQL span and `spark.sql.plan` already carries
+  the plan that ran. Its value is the diff: skew splits, broadcast conversion and partition
+  coalescing are only visible by comparing the two trees ([#54])
 - **`FLARE_SQL_PLAN_MAX_CHARS` / `FLARE_SQL_DETAILS_MAX_CHARS` /
   `FLARE_SQL_DESCRIPTION_MAX_CHARS`** — the SQL truncation caps above are now configurable rather
   than compiled in, so a deployment whose collector accepts larger payloads can keep the whole
@@ -82,6 +87,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of `flare-spark-assembly-${FLARE_VERSION}.jar`; removed `FLARE_VERSION` build arg
 
 ### Fixed
+- **`spark.sql.plan` is the plan that ran, not the pre-AQE tree** — `SparkListenerSQLExecutionStart`
+  fires before Adaptive Query Execution re-plans, so the captured tree always ended
+  `isFinalPlan=false` and described a query that in general never executed. Observed in the dev
+  stack: a plan claiming `hashpartitioning(region, tier, 200)` on a trace whose stage spans had
+  a task count of 1-2. `SparkListenerSQLAdaptiveExecutionUpdate` is now handled and overwrites the
+  attribute, so the last plan AQE produced is the one retained. Several updates per execution each
+  overwrite the last, so the cost is bounded however many times AQE re-plans. The truncation flag
+  is recomputed on overwrite — OTEL attributes cannot be removed, so a shorter replacement plan
+  explicitly clears a `spark.sql.plan.truncated=true` left by its predecessor ([#54])
 - **`FLARE_SLOW_TASK_MS` now actually suppresses spans** — it never has. The abandon path in
   `FlareExecutorPlugin.endTask` ended with a `return` from inside a closure passed to `foreach`,
   which in Scala compiles to a thrown `NonLocalReturnControl`. The enclosing `try`'s `finally`
@@ -219,5 +233,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#47]: https://github.com/Neutrinic/flare/issues/47
 [#52]: https://github.com/Neutrinic/flare/issues/52
 [#53]: https://github.com/Neutrinic/flare/issues/53
+[#54]: https://github.com/Neutrinic/flare/issues/54
 [#57]: https://github.com/Neutrinic/flare/issues/57
 [#58]: https://github.com/Neutrinic/flare/issues/58

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ available even when a cluster-wide one is not — notebooks and `spark-shell` in
 | `FLARE_SQL_PLAN_MAX_CHARS` | `4096` | Cap on `spark.sql.plan`; `0` drops the attribute |
 | `FLARE_SQL_DETAILS_MAX_CHARS` | `2048` | Cap on `spark.sql.details`; `0` drops the attribute |
 | `FLARE_SQL_DESCRIPTION_MAX_CHARS` | `1024` | Cap on `spark.sql.description`; `0` drops the attribute |
+| `FLARE_SQL_PLAN_INITIAL_MAX_CHARS` | `0` (dropped) | Cap on `spark.sql.plan.initial`, the pre-AQE plan |
 | `FLARE_ENABLED` | `true` | Kill switch |
 
 Set via `-DFLARE_*` in `extraJavaOptions` or as environment variables. System properties take
@@ -179,6 +180,14 @@ of kilobytes, which is enough to push an OTLP batch past a collector's message l
 whole batch rather than just the plan. Raise `FLARE_SQL_PLAN_MAX_CHARS` if your collector accepts
 larger payloads. When a plan is clipped, `spark.sql.plan.truncated=true` is set alongside it, so a
 partial plan never reads as a complete one.
+
+`spark.sql.plan` holds the plan that ran. Spark reports the physical plan when the execution
+starts, which is before Adaptive Query Execution re-plans, so that first tree always ends
+`isFinalPlan=false` and can describe a partitioning that never happened. Each AQE re-plan
+overwrites the attribute, leaving the final tree. Set `FLARE_SQL_PLAN_INITIAL_MAX_CHARS` above `0`
+to also retain the pre-AQE tree as `spark.sql.plan.initial` — the AQE decision (skew splits,
+broadcast conversion, partition coalescing) is only visible by diffing the two. It is off by
+default because it doubles the worst-case plan payload on every SQL span.
 
 ### Resource Attributes
 

--- a/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
+++ b/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
@@ -47,8 +47,15 @@ object SparkAttributes {
     val Description = AttributeKey.stringKey("spark.sql.description")
     val Details     = AttributeKey.stringKey("spark.sql.details")
     // physicalPlanDescription — the formatted plan, truncated on the way in.
+    // Holds the LATEST plan seen: the tree from SparkListenerSQLExecutionStart until AQE
+    // re-plans, then each SparkListenerSQLAdaptiveExecutionUpdate overwrites it. So this is
+    // the plan that ran, not the pre-AQE tree that always reports isFinalPlan=false.
     val Plan          = AttributeKey.stringKey("spark.sql.plan")
     val PlanTruncated = AttributeKey.booleanKey("spark.sql.plan.truncated")
+    // The pre-AQE tree, retained separately so the AQE decision is recoverable as a diff.
+    // Off by default — see FLARE_SQL_PLAN_INITIAL_MAX_CHARS.
+    val PlanInitial          = AttributeKey.stringKey("spark.sql.plan.initial")
+    val PlanInitialTruncated = AttributeKey.booleanKey("spark.sql.plan.initial.truncated")
   }
 
   object Task {

--- a/src/main/scala/io/flare/spark/config/FlareConfig.scala
+++ b/src/main/scala/io/flare/spark/config/FlareConfig.scala
@@ -38,6 +38,10 @@ final case class FlareConfig(
   sqlPlanMaxChars:        Int = FlareConfig.DefaultSqlPlanChars,
   sqlDetailsMaxChars:     Int = FlareConfig.DefaultSqlDetailsChars,
   sqlDescriptionMaxChars: Int = FlareConfig.DefaultSqlDescriptionChars,
+  // Cap for the retained pre-AQE plan. Defaults to 0 (dropped) because keeping it doubles the
+  // worst-case plan payload on every SQL span, and the post-AQE plan is the one that ran.
+  // Raise it when you want the AQE decision itself, recoverable as a diff against spark.sql.plan.
+  sqlPlanInitialMaxChars: Int = FlareConfig.DefaultSqlPlanInitialChars,
 ) {
   def tracesJobs:        Boolean = enabled
   def tracesStages:      Boolean = enabled && granularity != TraceGranularity.Jobs
@@ -99,6 +103,19 @@ object FlareConfig {
   val DefaultSqlPlanChars        = 4096
   val DefaultSqlDetailsChars     = 2048
   val DefaultSqlDescriptionChars = 1024
+
+  /**
+   * The pre-AQE plan is off by default.
+   *
+   * `spark.sql.plan` already carries the plan that ran. Retaining the initial tree as well
+   * doubles the worst-case plan payload on every SQL span, and for the common case — "what did
+   * this query actually do" — it answers nothing the primary attribute does not.
+   *
+   * Its value is the diff: what AQE decided. Skew splits, broadcast conversion and partition
+   * coalescing are only visible by comparing the two. That is a deliberate investigation, so it
+   * is opt-in via FLARE_SQL_PLAN_INITIAL_MAX_CHARS.
+   */
+  val DefaultSqlPlanInitialChars = 0
 
   /**
    * Read a config value from system properties first, then environment variables.
@@ -210,6 +227,7 @@ object FlareConfig {
       sqlPlanMaxChars        = charCap("FLARE_SQL_PLAN_MAX_CHARS", DefaultSqlPlanChars),
       sqlDetailsMaxChars     = charCap("FLARE_SQL_DETAILS_MAX_CHARS", DefaultSqlDetailsChars),
       sqlDescriptionMaxChars = charCap("FLARE_SQL_DESCRIPTION_MAX_CHARS", DefaultSqlDescriptionChars),
+      sqlPlanInitialMaxChars = charCap("FLARE_SQL_PLAN_INITIAL_MAX_CHARS", DefaultSqlPlanInitialChars),
     )
   }
 }

--- a/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
+++ b/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
@@ -9,6 +9,7 @@ import io.opentelemetry.api.trace.{Span, SpanKind, StatusCode, Tracer}
 import io.opentelemetry.context.Context
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.execution.ui.{
+  SparkListenerSQLAdaptiveExecutionUpdate,
   SparkListenerSQLExecutionEnd,
   SparkListenerSQLExecutionStart,
 }
@@ -263,6 +264,12 @@ class TracingSparkListener(
             SubmitMissingTasksAdviceHelper.activeSQLSpans.put(e.executionId, span)
           }
         }
+        // AQE re-plans after execution starts, so the tree captured at start is provisional.
+        // Every update carries the current plan; the last one to arrive is what ran.
+        case e: SparkListenerSQLAdaptiveExecutionUpdate => safeHandle("onSQLAdaptiveUpdate") {
+          Option(SubmitMissingTasksAdviceHelper.activeSQLSpans.get(e.executionId))
+            .foreach(span => updateSqlPlan(span, e.physicalPlanDescription))
+        }
         case e: SparkListenerSQLExecutionEnd => safeHandle("onSQLEnd") {
           Option(SubmitMissingTasksAdviceHelper.activeSQLSpans.remove(e.executionId))
             .foreach { span =>
@@ -327,12 +334,57 @@ class TracingSparkListener(
     setIfNonEmpty(span, Sql.Description, description, config.sqlDescriptionMaxChars)
     setIfNonEmpty(span, Sql.Details, details, config.sqlDetailsMaxChars)
 
-    val plan = Option(physicalPlanDescription).getOrElse("")
-    if (plan.nonEmpty && config.sqlPlanMaxChars > 0) {
-      span.setAttribute(Sql.Plan, plan.take(config.sqlPlanMaxChars))
+    // The plan is provisional at this point — AQE has not run. If it re-plans,
+    // SparkListenerSQLAdaptiveExecutionUpdate overwrites Sql.Plan with the tree that ran.
+    // If it never fires, this plan is final and the value stands.
+    setPlan(span, Sql.Plan, Sql.PlanTruncated, physicalPlanDescription, config.sqlPlanMaxChars)
+
+    // Retained separately so the AQE decision survives the overwrite. Off unless configured.
+    setPlan(
+      span,
+      Sql.PlanInitial,
+      Sql.PlanInitialTruncated,
+      physicalPlanDescription,
+      config.sqlPlanInitialMaxChars,
+    )
+  }
+
+  /**
+   * Replaces `spark.sql.plan` with a plan produced by AQE.
+   *
+   * Called once per SparkListenerSQLAdaptiveExecutionUpdate. Several may arrive for one
+   * execution; each overwrites the last, so only the final state is retained and the cost is
+   * bounded regardless of how many times AQE re-plans.
+   */
+  private[listener] def updateSqlPlan(span: Span, physicalPlanDescription: String): Unit =
+    setPlan(
+      span,
+      Sql.Plan,
+      Sql.PlanTruncated,
+      physicalPlanDescription,
+      config.sqlPlanMaxChars,
+      // The previous plan may have set the truncation flag. Attributes cannot be removed, so an
+      // overwrite that no longer truncates has to say so explicitly or the stale `true` stands.
+      clearTruncationFlag = true,
+    )
+
+  /** Sets a plan attribute and its truncation flag, honouring `maxChars` (0 drops both). */
+  private def setPlan(
+    span:                Span,
+    key:                 io.opentelemetry.api.common.AttributeKey[String],
+    truncatedKey:        io.opentelemetry.api.common.AttributeKey[java.lang.Boolean],
+    value:               String,
+    maxChars:            Int,
+    clearTruncationFlag: Boolean = false,
+  ): Unit = {
+    val plan = Option(value).getOrElse("")
+    if (plan.nonEmpty && maxChars > 0) {
+      span.setAttribute(key, plan.take(maxChars))
       // Flag truncation explicitly. A silently clipped plan reads exactly like a complete one,
       // which is worse than no plan at all when someone is diagnosing a slow join.
-      if (plan.length > config.sqlPlanMaxChars) span.setBool(Sql.PlanTruncated, true)
+      val truncated = plan.length > maxChars
+      if (truncated) span.setBool(truncatedKey, true)
+      else if (clearTruncationFlag) span.setBool(truncatedKey, false)
     }
   }
 

--- a/src/test/scala/io/flare/spark/config/FlareConfigTest.scala
+++ b/src/test/scala/io/flare/spark/config/FlareConfigTest.scala
@@ -137,6 +137,7 @@ class FlareConfigTest extends FunSuite {
     "FLARE_MAX_SPANS_PER_TRACE", "FLARE_SLOW_TASK_MS", "FLARE_RETRY_TASKS_ONLY",
     "FLARE_TASK_STAGES", "FLARE_TASK_STAGE_PATTERN", "FLARE_METRICS_ENABLED",
     "FLARE_SQL_PLAN_MAX_CHARS", "FLARE_SQL_DETAILS_MAX_CHARS", "FLARE_SQL_DESCRIPTION_MAX_CHARS",
+    "FLARE_SQL_PLAN_INITIAL_MAX_CHARS",
   )
 
   override def afterEach(context: AfterEach): Unit = {
@@ -206,6 +207,23 @@ class FlareConfigTest extends FunSuite {
     assertEquals(config.sqlPlanMaxChars, 4096)
     assertEquals(config.sqlDetailsMaxChars, 2048)
     assertEquals(config.sqlDescriptionMaxChars, 1024)
+    // The pre-AQE plan is opt-in: it doubles the plan payload and spark.sql.plan already
+    // carries the plan that ran.
+    assertEquals(config.sqlPlanInitialMaxChars, 0)
+  }
+
+  test("load() parses FLARE_SQL_PLAN_INITIAL_MAX_CHARS") {
+    sys.props("FLARE_SQL_PLAN_INITIAL_MAX_CHARS") = "8192"
+    assertEquals(FlareConfig.load().sqlPlanInitialMaxChars, 8192)
+  }
+
+  test("load() throws on a negative FLARE_SQL_PLAN_INITIAL_MAX_CHARS") {
+    sys.props("FLARE_SQL_PLAN_INITIAL_MAX_CHARS") = "-5"
+    interceptMessage[IllegalArgumentException](
+      "Flare config error: FLARE_SQL_PLAN_INITIAL_MAX_CHARS must be >= 0, got -5"
+    ) {
+      FlareConfig.load()
+    }
   }
 
   test("load() parses the SQL truncation caps") {

--- a/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
+++ b/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
@@ -11,6 +11,7 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import munit.FunSuite
 import org.apache.spark.FlareTestHelpers
 import org.apache.spark.scheduler._
+import org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
 
 import scala.collection.JavaConverters._
 
@@ -394,6 +395,135 @@ class TracingSparkListenerTest extends FunSuite {
       listener.describeSqlExecution(span, executionId, description, details, plan)
       span.end()
       exporter.getFinishedSpanItems.asScala.head.getAttributes
+    } finally provider.close()
+  }
+
+  /**
+   * Drives a SQL execution through start and then an AQE re-plan, and returns the attributes
+   * left on the span.
+   *
+   * Unlike SparkListenerSQLExecutionStart, SparkListenerSQLAdaptiveExecutionUpdate's constructor
+   * is identical on 3.3.4, 3.4.3, 3.5.1 and 4.0.0 — `(long, String, SparkPlanInfo)` — so the real
+   * event can be constructed and dispatched through onOtherEvent on every version we build.
+   * SparkPlanInfo is never read, so it is left null rather than dragging in a second fixture
+   * whose constructor is not stable.
+   */
+  def sqlAqeAttributes(
+    startPlan:   String,
+    aqePlans:    Seq[String],
+    executionId: Long        = 7L,
+    sqlConfig:   FlareConfig = config,
+  ): Attributes = {
+    val exporter = InMemorySpanExporter.create()
+    val provider = SdkTracerProvider.builder()
+      .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+      .build()
+    try {
+      val tracer   = provider.get("io.flare.spark.test")
+      val listener = new TracingSparkListener(tracer, sqlConfig, throwOnError = true)
+      val span     = tracer.spanBuilder(s"spark.sql.$executionId").startSpan()
+      listener.describeSqlExecution(span, executionId, "", "", startPlan)
+
+      SubmitMissingTasksAdviceHelper.activeSQLSpans.put(executionId, span)
+      try {
+        aqePlans.foreach { p =>
+          listener.onOtherEvent(
+            new SparkListenerSQLAdaptiveExecutionUpdate(executionId, p, null)
+          )
+        }
+      } finally SubmitMissingTasksAdviceHelper.activeSQLSpans.remove(executionId)
+
+      span.end()
+      exporter.getFinishedSpanItems.asScala.head.getAttributes
+    } finally provider.close()
+  }
+
+  // ── #54: spark.sql.plan must be the plan that ran, not the pre-AQE tree ─────
+
+  test("an AQE re-plan overwrites spark.sql.plan") {
+    val attrs = sqlAqeAttributes(
+      startPlan = "AdaptiveSparkPlan isFinalPlan=false",
+      aqePlans  = Seq("AdaptiveSparkPlan isFinalPlan=true"),
+    )
+    // The pre-AQE tree describes partitioning that never ran. The post-AQE tree is what executed.
+    assertEquals(attrs.get(Sql.Plan), "AdaptiveSparkPlan isFinalPlan=true")
+  }
+
+  test("the last AQE update wins when several arrive") {
+    val attrs = sqlAqeAttributes(
+      startPlan = "initial",
+      aqePlans  = Seq("replan-1", "replan-2", "final"),
+    )
+    assertEquals(attrs.get(Sql.Plan), "final")
+  }
+
+  test("spark.sql.plan is unchanged when AQE never re-plans") {
+    val attrs = sqlAqeAttributes(startPlan = "only plan", aqePlans = Nil)
+    assertEquals(attrs.get(Sql.Plan), "only plan")
+  }
+
+  test("the pre-AQE plan is dropped by default") {
+    val attrs = sqlAqeAttributes(startPlan = "initial", aqePlans = Seq("final"))
+    // Retaining it doubles the plan payload on every SQL span, so it is opt-in.
+    assertEquals(attrs.get(Sql.PlanInitial), null)
+    assertEquals(attrs.get(Sql.PlanInitialTruncated), null)
+  }
+
+  test("the pre-AQE plan is retained when FLARE_SQL_PLAN_INITIAL_MAX_CHARS allows it") {
+    val attrs = sqlAqeAttributes(
+      startPlan = "initial",
+      aqePlans  = Seq("final"),
+      sqlConfig = config.copy(sqlPlanInitialMaxChars = 4096),
+    )
+    // Both are needed: the AQE decision is only visible as the diff between them.
+    assertEquals(attrs.get(Sql.PlanInitial), "initial")
+    assertEquals(attrs.get(Sql.Plan), "final")
+  }
+
+  test("the pre-AQE plan is truncated and flagged independently of the final plan") {
+    val attrs = sqlAqeAttributes(
+      startPlan = "X" * 100,
+      aqePlans  = Seq("short"),
+      sqlConfig = config.copy(sqlPlanMaxChars = 4096, sqlPlanInitialMaxChars = 10),
+    )
+    assertEquals(attrs.get(Sql.PlanInitial).length, 10)
+    assertEquals(attrs.get(Sql.PlanInitialTruncated).booleanValue(), true)
+    assertEquals(attrs.get(Sql.Plan), "short")
+    assertEquals(attrs.get(Sql.PlanTruncated).booleanValue(), false)
+  }
+
+  test("an AQE update clears a truncation flag set by the pre-AQE plan") {
+    val attrs = sqlAqeAttributes(
+      startPlan = "X" * 100,
+      aqePlans  = Seq("short"),
+      sqlConfig = config.copy(sqlPlanMaxChars = 10),
+    )
+    // Attributes cannot be removed. Without an explicit false, the stale true from the initial
+    // plan would still be on the span, marking a complete plan as clipped.
+    assertEquals(attrs.get(Sql.Plan), "short")
+    assertEquals(attrs.get(Sql.PlanTruncated).booleanValue(), false)
+  }
+
+  test("an AQE update still flags truncation when the new plan is too long") {
+    val attrs = sqlAqeAttributes(
+      startPlan = "short",
+      aqePlans  = Seq("Y" * 100),
+      sqlConfig = config.copy(sqlPlanMaxChars = 10),
+    )
+    assertEquals(attrs.get(Sql.Plan).length, 10)
+    assertEquals(attrs.get(Sql.PlanTruncated).booleanValue(), true)
+  }
+
+  test("an AQE update for an unknown execution id is ignored") {
+    val exporter = InMemorySpanExporter.create()
+    val provider = SdkTracerProvider.builder()
+      .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+      .build()
+    try {
+      val listener = new TracingSparkListener(
+        provider.get("io.flare.spark.test"), config, throwOnError = true)
+      // No span registered for 999 — must not throw.
+      listener.onOtherEvent(new SparkListenerSQLAdaptiveExecutionUpdate(999L, "plan", null))
     } finally provider.close()
   }
 


### PR DESCRIPTION
Closes #54

## Summary

`spark.sql.plan` has always held the **pre-AQE** plan. `SparkListenerSQLExecutionStart` fires before Adaptive Query Execution runs, so the tree it carries always ends `isFinalPlan=false` and can state things that are false. Observed in the dev stack: a plan claiming `hashpartitioning(region#3, tier#133, 200)` on a trace whose stage spans reported a task count of 1-2.

- `SparkListenerSQLAdaptiveExecutionUpdate` is now handled. Each update overwrites `spark.sql.plan`, so the retained tree is the last one AQE produced — the plan that ran. Several updates can arrive per execution; each overwrites the last, so the cost is bounded however many times AQE re-plans. If AQE never fires, the plan captured at start is final and stands unchanged.
- The pre-AQE tree is retained separately as `spark.sql.plan.initial`, gated on the new `FLARE_SQL_PLAN_INITIAL_MAX_CHARS`. **Off by default (`0`)**: it doubles the worst-case plan payload on every SQL span, and `spark.sql.plan` already answers "what did this query do". Its value is the diff — skew splits, broadcast conversion and partition coalescing are only visible by comparing the two — which is a deliberate investigation, so it is opt-in. This settles the open question in the issue.
- Truncation flags are independent per attribute. OTEL attributes cannot be removed, only overwritten, so the AQE path explicitly sets `spark.sql.plan.truncated=false` when a shorter replacement plan no longer truncates; otherwise a stale `true` would survive and misreport a complete plan as clipped.

`SparkListenerSQLAdaptiveExecutionUpdate`'s constructor is `(long, String, SparkPlanInfo)` and was verified with `javap` to be byte-for-byte identical on 3.3.4, 3.4.3, 3.5.1 and 4.0.0 — unlike `SparkListenerSQLExecutionStart`, whose parameters shift across the matrix. So the tests construct and dispatch the real event on every supported version rather than a fixture.

## Test plan
- [x] 9 new tests in `TracingSparkListenerTest`: overwrite on re-plan, last-update-wins, unchanged when AQE never fires, initial plan dropped by default, retained when configured, truncated independently, flag cleared on overwrite, flag re-set when the new plan is too long, unknown execution id ignored
- [x] 3 changes in `FlareConfigTest`: default `0`, parses `8192`, rejects a negative value
- [x] Proven non-vacuous — with the handler neutered, 6 tests fail with obtained `AdaptiveSparkPlan isFinalPlan=false`, reproducing the issue exactly
- [x] `sbt -DsparkVersion=3.5.1 ++2.13.16 test` — 128 passed
- [x] `sbt -DsparkVersion=3.5.1 ++2.12.18 test` — 128 passed
- [x] `Test / compile` on 3.3.4, 3.4.3, 4.0.0 (2.13.16) — all `[success]`
- [x] README config table + prose, CHANGELOG entry, and correction to the existing `spark.sql.plan` bullet from #44 (which described the pre-AQE attribute)