### PR TITLE
Record the stage timing breakdown, not just the total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Stage timing breakdown** — `spark.stage.jvm.gc_time_ms`,
+  `spark.stage.executor.deserialize_time_ms`, `spark.stage.executor.deserialize_cpu_time_ms`,
+  `spark.stage.result.serialization_time_ms`, `spark.stage.disk.spilled_bytes` and
+  `spark.stage.scheduler.delay_ms`. Total stage duration says a stage was slow; these say why,
+  and GC time in particular is often the whole answer. All are sums across the stage's tasks, so
+  they are directly comparable with the existing `spark.stage.executor.run_time_ms`.
+  Scheduler delay is the only one Spark does not report: it is derived per task as the wall clock
+  left after deserialization, run time, result serialization and result fetch, then summed.
+  It is clamped at zero per task rather than on the sum, because the driver and executor clocks
+  are different clocks and a fast task can report slightly more run time than its own duration —
+  summing first would let that cancel real queueing measured elsewhere in the stage. The
+  attribute is omitted entirely, rather than exported as `0`, for a stage that reported no task
+  ends, so "not measured" never reads as "no queueing" ([#45])
 - **SQL execution metadata on `spark.sql.N` spans** — the span previously carried no attributes
   at all. It now records `spark.sql.execution.id`, `spark.sql.description`, `spark.sql.details`
   and `spark.sql.plan` (the formatted physical plan), all sourced from
@@ -216,6 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#26]: https://github.com/Neutrinic/flare/issues/26
 [#42]: https://github.com/Neutrinic/flare/issues/42
 [#44]: https://github.com/Neutrinic/flare/issues/44
+[#45]: https://github.com/Neutrinic/flare/issues/45
 [#47]: https://github.com/Neutrinic/flare/issues/47
 [#52]: https://github.com/Neutrinic/flare/issues/52
 [#53]: https://github.com/Neutrinic/flare/issues/53

--- a/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
+++ b/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
@@ -32,7 +32,22 @@ object SparkAttributes {
     val ShuffleReadBytes  = AttributeKey.longKey("spark.stage.shuffle.read_bytes")
     val ShuffleWriteBytes = AttributeKey.longKey("spark.stage.shuffle.write_bytes")
     val MemorySpilled   = AttributeKey.longKey("spark.stage.memory.spilled_bytes")
+    val DiskSpilled     = AttributeKey.longKey("spark.stage.disk.spilled_bytes")
     val FailureReason   = AttributeKey.stringKey("spark.stage.failure_reason")
+
+    /**
+     * Where a slow stage's time actually went.
+     *
+     * Like ExecutorRunTime above, each of these is Spark's own sum across every task in the
+     * stage, so they are directly comparable with it — a stage whose GC time rivals its run
+     * time has its answer right here, and total duration alone never shows that.
+     */
+    val JvmGcTime                  = AttributeKey.longKey("spark.stage.jvm.gc_time_ms")
+    val ExecutorDeserializeTime    = AttributeKey.longKey("spark.stage.executor.deserialize_time_ms")
+    val ExecutorDeserializeCpuTime = AttributeKey.longKey("spark.stage.executor.deserialize_cpu_time_ms")
+    val ResultSerializationTime    = AttributeKey.longKey("spark.stage.result.serialization_time_ms")
+    // Derived rather than reported — see TracingSparkListener.schedulerDelayMs.
+    val SchedulerDelay             = AttributeKey.longKey("spark.stage.scheduler.delay_ms")
   }
 
   /**

--- a/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
+++ b/src/main/scala/io/flare/spark/listener/TracingSparkListener.scala
@@ -14,6 +14,7 @@ import org.apache.spark.sql.execution.ui.{
 }
 import org.slf4j.LoggerFactory
 
+import java.util.concurrent.atomic.AtomicLong
 import scala.collection.concurrent.TrieMap
 
 /**
@@ -44,6 +45,12 @@ class TracingSparkListener(
   // Reverse index: stageId → jobId, built at onJobStart from jobStart.stageIds
   // Critical for correct parent attribution when multiple jobs run concurrently
   private val stageToJob: TrieMap[Int, Int] = TrieMap.empty
+
+  // stageId → summed scheduler delay across the stage's tasks, accumulated at onTaskEnd.
+  // Unlike every other stage attribute this one is not on StageInfo.taskMetrics: deriving it
+  // needs each task's wall clock, which only SparkListenerTaskEnd carries. One Long per
+  // in-flight stage.
+  private val stageSchedulerDelayMs: TrieMap[Int, AtomicLong] = TrieMap.empty
 
   // Set by whoever creates this listener (TracingSparkPlugin or ByteBuddy hook)
   @volatile private var applicationSpan: Option[Span] = None
@@ -192,8 +199,65 @@ class TracingSparkListener(
       logger.debug(s"[Flare] Stage $stageId submitted")
     }
 
+  /**
+   * Accumulates scheduler delay. No task span is created here — see the class comment.
+   *
+   * Scheduler delay is the one part of the stage breakdown Spark does not report. It has to be
+   * derived per task, because it needs the task's wall clock, which lives on TaskInfo rather
+   * than TaskMetrics.
+   */
+  override def onTaskEnd(event: SparkListenerTaskEnd): Unit =
+    if (config.tracesStages) safeHandle("onTaskEnd") {
+      val info = event.taskInfo
+      // taskMetrics is null when a task failed before it could report any, and duration throws
+      // outright on a task that never finished. Neither yields a delay worth deriving.
+      if (info != null && info.finished && event.taskMetrics != null) {
+        val m = event.taskMetrics
+        // TaskInfo.gettingResultTime is the instant the driver started fetching an indirect
+        // result, not an elapsed time, and stays 0 when the result came back inline.
+        val gettingResultMs =
+          if (info.gettingResultTime > 0) math.max(0L, info.finishTime - info.gettingResultTime)
+          else 0L
+        val delay = schedulerDelayMs(
+          durationMs                = info.duration,
+          executorRunTimeMs         = m.executorRunTime,
+          deserializeTimeMs         = m.executorDeserializeTime,
+          resultSerializationTimeMs = m.resultSerializationTime,
+          gettingResultTimeMs       = gettingResultMs,
+        )
+        stageSchedulerDelayMs.getOrElseUpdate(event.stageId, new AtomicLong()).addAndGet(delay)
+      }
+    }
+
+  /**
+   * The part of a task's wall clock that was not spent doing the task.
+   *
+   * Everything Spark measures about a task — deserializing it, running it, serializing the
+   * result, shipping that result back — is subtracted from the wall clock the driver observed.
+   * What remains is queueing: waiting for an executor slot, and the scheduler round trip.
+   *
+   * Clamped at zero per task, deliberately, and never on the sum. The driver's clock and the
+   * executor's are different clocks, so a fast task can report a run time a few ms longer than
+   * its own duration. Summing first would let those negatives cancel real delay elsewhere in
+   * the stage and quietly understate it.
+   */
+  private[listener] def schedulerDelayMs(
+    durationMs:                Long,
+    executorRunTimeMs:         Long,
+    deserializeTimeMs:         Long,
+    resultSerializationTimeMs: Long,
+    gettingResultTimeMs:       Long,
+  ): Long =
+    math.max(
+      0L,
+      durationMs - executorRunTimeMs - deserializeTimeMs - resultSerializationTimeMs - gettingResultTimeMs,
+    )
+
   override def onStageCompleted(event: SparkListenerStageCompleted): Unit = {
     val stageId = event.stageInfo.stageId
+    // Removed unconditionally: a stage whose span was never created still accumulated delay,
+    // and this is the only event that tells us the stage is over.
+    val schedulerDelay = stageSchedulerDelayMs.remove(stageId)
     activeStageSpans.remove(stageId).foreach { span =>
       safeHandle("onStageCompleted") {
         // Record task metrics as stage attributes
@@ -207,6 +271,13 @@ class TracingSparkListener(
           span.setLong(Stage.ShuffleReadBytes, m.shuffleReadMetrics.totalBytesRead)
           span.setLong(Stage.ShuffleWriteBytes, m.shuffleWriteMetrics.bytesWritten)
           span.setLong(Stage.MemorySpilled, m.memoryBytesSpilled)
+          span.setLong(Stage.DiskSpilled, m.diskBytesSpilled)
+
+          // The breakdown of a slow stage. Total duration says a stage was slow; these say why.
+          span.setLong(Stage.JvmGcTime, m.jvmGCTime)
+          span.setLong(Stage.ExecutorDeserializeTime, m.executorDeserializeTime)
+          span.setLong(Stage.ExecutorDeserializeCpuTime, m.executorDeserializeCpuTime / 1000000L) // ns → ms
+          span.setLong(Stage.ResultSerializationTime, m.resultSerializationTime)
 
           // Record OTEL stage-level metrics
           metrics.foreach { fm =>
@@ -222,6 +293,10 @@ class TracingSparkListener(
             if (shuffleWrite > 0) fm.stageShuffleWriteBytes.add(shuffleWrite, attrs)
           }
         }
+
+        // Only set when task ends were actually observed. A stage that reported none would
+        // otherwise export a zero, which reads as "no queueing" rather than "not measured".
+        schedulerDelay.foreach(d => span.setLong(Stage.SchedulerDelay, d.get()))
 
         event.stageInfo.failureReason match {
           case Some(reason) =>
@@ -286,6 +361,7 @@ class TracingSparkListener(
     sqlSpans.clear()
     applicationSpan.foreach(_.end())
     stageToJob.clear()
+    stageSchedulerDelayMs.clear()
   }
 
   // ── Utilities ─────────────────────────────────────────────────────────────────

--- a/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
+++ b/src/test/scala/io/flare/spark/listener/TracingSparkListenerTest.scala
@@ -9,7 +9,8 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import munit.FunSuite
-import org.apache.spark.FlareTestHelpers
+import org.apache.spark.{FlareTestHelpers, Success, TaskResultLost}
+import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.scheduler._
 
 import scala.collection.JavaConverters._
@@ -201,6 +202,166 @@ class TracingSparkListenerTest extends FunSuite {
       assert(attrs.get(Stage.ShuffleReadBytes) != null, "shuffleReadBytes attribute missing")
       assert(attrs.get(Stage.ShuffleWriteBytes) != null, "shuffleWriteBytes attribute missing")
     }
+  }
+
+  // ── Stage timing breakdown (#45) ────────────────────────────────────────────
+
+  /**
+   * Runs one stage end to end with the given per-task events and stage-level TaskMetrics,
+   * and returns the attributes left on its span.
+   */
+  def stageAttributes(
+    stageMetrics: TaskMetrics,
+    taskEnds:     Seq[SparkListenerTaskEnd] = Nil,
+  ): Attributes = {
+    var attrs: Attributes = Attributes.empty()
+    withListener { (listener, exporter) =>
+      listener.onJobStart(makeJobStart(0, Seq(0)))
+      listener.onStageSubmitted(makeStageSubmitted(0))
+      taskEnds.foreach(listener.onTaskEnd)
+      listener.onStageCompleted(SparkListenerStageCompleted(
+        FlareTestHelpers.makeStageInfo(0, "stage-0", taskMetrics = stageMetrics)
+      ))
+      listener.onJobEnd(makeJobEnd(0, succeeded = true))
+      listener.shutdown()
+      attrs = exporter.getFinishedSpanItems.asScala.find(_.getName == "spark.stage.0").get.getAttributes
+    }
+    attrs
+  }
+
+  def makeTaskEnd(
+    taskId:              Long,
+    durationMs:          Long,
+    runTimeMs:           Long = 0L,
+    deserializeMs:       Long = 0L,
+    serializeMs:         Long = 0L,
+    gettingResultTimeMs: Long = 0L,
+    stageId:             Int  = 0,
+  ): SparkListenerTaskEnd =
+    SparkListenerTaskEnd(
+      stageId        = stageId,
+      stageAttemptId = 0,
+      taskType       = "ResultTask",
+      reason         = Success,
+      taskInfo       = FlareTestHelpers.finishedTaskInfo(taskId, durationMs, gettingResultTimeMs),
+      taskExecutorMetrics = FlareTestHelpers.emptyExecutorMetrics(),
+      taskMetrics = FlareTestHelpers.taskMetrics(
+        executorRunTime         = runTimeMs,
+        executorDeserializeTime = deserializeMs,
+        resultSerializationTime = serializeMs,
+      ),
+    )
+
+  test("stage span records the timing breakdown and disk spill") {
+    val attrs = stageAttributes(FlareTestHelpers.taskMetrics(
+      jvmGcTime                  = 420L,
+      executorDeserializeTime    = 35L,
+      executorDeserializeCpuTime = 12000000L, // ns
+      resultSerializationTime    = 7L,
+      memoryBytesSpilled         = 2048L,
+      diskBytesSpilled           = 4096L,
+    ))
+
+    assertEquals(attrs.get(Stage.JvmGcTime).longValue(), 420L)
+    assertEquals(attrs.get(Stage.ExecutorDeserializeTime).longValue(), 35L)
+    assertEquals(attrs.get(Stage.ResultSerializationTime).longValue(), 7L)
+    assertEquals(attrs.get(Stage.MemorySpilled).longValue(), 2048L)
+    assertEquals(attrs.get(Stage.DiskSpilled).longValue(), 4096L)
+  }
+
+  test("deserialize CPU time is converted from nanoseconds, like executor CPU time") {
+    val attrs = stageAttributes(
+      FlareTestHelpers.taskMetrics(executorDeserializeCpuTime = 12345000000L)
+    )
+    assertEquals(attrs.get(Stage.ExecutorDeserializeCpuTime).longValue(), 12345L)
+  }
+
+  test("scheduler delay is the wall clock left over after the measured work") {
+    // 500ms wall clock, of which 300 ran, 20 deserialized and 5 serialized → 175 queued.
+    val attrs = stageAttributes(
+      FlareTestHelpers.emptyTaskMetrics(),
+      Seq(makeTaskEnd(1L, durationMs = 500L, runTimeMs = 300L, deserializeMs = 20L, serializeMs = 5L)),
+    )
+    assertEquals(attrs.get(Stage.SchedulerDelay).longValue(), 175L)
+  }
+
+  test("scheduler delay sums across the stage's tasks") {
+    val attrs = stageAttributes(
+      FlareTestHelpers.emptyTaskMetrics(),
+      Seq(
+        makeTaskEnd(1L, durationMs = 500L, runTimeMs = 300L),
+        makeTaskEnd(2L, durationMs = 200L, runTimeMs = 150L),
+      ),
+    )
+    assertEquals(attrs.get(Stage.SchedulerDelay).longValue(), 250L)
+  }
+
+  test("result fetch time is not counted as scheduler delay") {
+    val attrs = stageAttributes(
+      FlareTestHelpers.emptyTaskMetrics(),
+      Seq(makeTaskEnd(1L, durationMs = 500L, runTimeMs = 300L, gettingResultTimeMs = 120L)),
+    )
+    assertEquals(attrs.get(Stage.SchedulerDelay).longValue(), 80L)
+  }
+
+  test("a task whose reported work exceeds its wall clock contributes zero, not a negative") {
+    // Driver and executor clocks are not the same clock; run time can overshoot duration.
+    val attrs = stageAttributes(
+      FlareTestHelpers.emptyTaskMetrics(),
+      Seq(
+        makeTaskEnd(1L, durationMs = 100L, runTimeMs = 150L), // would be -50
+        makeTaskEnd(2L, durationMs = 500L, runTimeMs = 300L), // 200
+      ),
+    )
+    // Clamped per task: a skewed task must not cancel real delay measured elsewhere.
+    assertEquals(attrs.get(Stage.SchedulerDelay).longValue(), 200L)
+  }
+
+  test("scheduler delay is absent, not zero, when no task ends were observed") {
+    val attrs = stageAttributes(FlareTestHelpers.emptyTaskMetrics())
+    assert(attrs.get(Stage.SchedulerDelay) == null)
+  }
+
+  test("scheduler delay is attributed to the task's own stage") {
+    withListener { (listener, exporter) =>
+      listener.onJobStart(makeJobStart(0, Seq(0, 1)))
+      listener.onStageSubmitted(makeStageSubmitted(0))
+      listener.onStageSubmitted(makeStageSubmitted(1))
+
+      listener.onTaskEnd(makeTaskEnd(1L, durationMs = 500L, runTimeMs = 300L, stageId = 0))
+      listener.onTaskEnd(makeTaskEnd(2L, durationMs = 900L, runTimeMs = 300L, stageId = 1))
+
+      Seq(0, 1).foreach { id =>
+        listener.onStageCompleted(SparkListenerStageCompleted(
+          FlareTestHelpers.makeStageInfo(id, s"stage-$id", taskMetrics = FlareTestHelpers.emptyTaskMetrics())
+        ))
+      }
+      listener.onJobEnd(makeJobEnd(0, succeeded = true))
+      listener.shutdown()
+
+      val spans = exporter.getFinishedSpanItems.asScala
+      assertEquals(spans.find(_.getName == "spark.stage.0").get.getAttributes.get(Stage.SchedulerDelay).longValue(), 200L)
+      assertEquals(spans.find(_.getName == "spark.stage.1").get.getAttributes.get(Stage.SchedulerDelay).longValue(), 600L)
+    }
+  }
+
+  test("a task that failed before reporting metrics is skipped rather than throwing") {
+    val noMetrics = SparkListenerTaskEnd(
+      stageId             = 0,
+      stageAttemptId      = 0,
+      taskType            = "ResultTask",
+      reason              = TaskResultLost,
+      taskInfo            = FlareTestHelpers.finishedTaskInfo(1L, durationMs = 500L),
+      taskExecutorMetrics = FlareTestHelpers.emptyExecutorMetrics(),
+      taskMetrics         = null,
+    )
+    // throwOnError = true in withListener, so a NPE here would fail the test. The healthy task
+    // that follows proves the metric-less one was skipped rather than aborting the stage.
+    val attrs = stageAttributes(
+      FlareTestHelpers.emptyTaskMetrics(),
+      Seq(noMetrics, makeTaskEnd(2L, durationMs = 500L, runTimeMs = 300L)),
+    )
+    assertEquals(attrs.get(Stage.SchedulerDelay).longValue(), 200L)
   }
 
   test("stage span records failure reason on failed stage") {

--- a/src/test/scala/org/apache/spark/FlareTestHelpers.scala
+++ b/src/test/scala/org/apache/spark/FlareTestHelpers.scala
@@ -1,7 +1,7 @@
 package org.apache.spark
 
-import org.apache.spark.executor.TaskMetrics
-import org.apache.spark.scheduler.{JobFailed, JobResult, StageInfo}
+import org.apache.spark.executor.{ExecutorMetrics, TaskMetrics}
+import org.apache.spark.scheduler.{JobFailed, JobResult, StageInfo, TaskInfo, TaskLocality}
 
 /**
  * Test helpers in the org.apache.spark package to access private[spark] members.
@@ -10,6 +10,59 @@ import org.apache.spark.scheduler.{JobFailed, JobResult, StageInfo}
 object FlareTestHelpers {
 
   def emptyTaskMetrics(): TaskMetrics = new TaskMetrics()
+
+  def emptyExecutorMetrics(): ExecutorMetrics = new ExecutorMetrics()
+
+  /**
+   * TaskMetrics with the timing breakdown populated.
+   *
+   * All of these setters are private[spark] but signature-identical on 3.3.4, 3.4.3, 3.5.1 and
+   * 4.0.0 (verified with javap), so this compiles across the whole matrix.
+   */
+  def taskMetrics(
+    executorRunTime:            Long = 0L,
+    jvmGcTime:                  Long = 0L,
+    executorDeserializeTime:    Long = 0L,
+    executorDeserializeCpuTime: Long = 0L,
+    resultSerializationTime:    Long = 0L,
+    memoryBytesSpilled:         Long = 0L,
+    diskBytesSpilled:           Long = 0L,
+  ): TaskMetrics = {
+    val m = new TaskMetrics()
+    m.setExecutorRunTime(executorRunTime)
+    m.setJvmGCTime(jvmGcTime)
+    m.setExecutorDeserializeTime(executorDeserializeTime)
+    m.setExecutorDeserializeCpuTime(executorDeserializeCpuTime)
+    m.setResultSerializationTime(resultSerializationTime)
+    m.incMemoryBytesSpilled(memoryBytesSpilled)
+    m.incDiskBytesSpilled(diskBytesSpilled)
+    m
+  }
+
+  /**
+   * A finished TaskInfo whose wall clock is exactly `durationMs`.
+   *
+   * The 9-argument constructor (with partitionId) and markFinished are identical across
+   * 3.3.4-4.0.0, so this needs no per-version handling.
+   */
+  def finishedTaskInfo(
+    taskId:              Long = 0L,
+    durationMs:          Long = 0L,
+    gettingResultTimeMs: Long = 0L,
+  ): TaskInfo = {
+    val launchTime = 1000000L
+    val info = new TaskInfo(
+      taskId, taskId.toInt, 0, taskId.toInt, launchTime,
+      "exec-1", "host-1", TaskLocality.PROCESS_LOCAL, false,
+    )
+    // gettingResultTime is the instant the fetch began, so back it off the finish time to get
+    // the elapsed value the caller asked for.
+    if (gettingResultTimeMs > 0) {
+      info.gettingResultTime = launchTime + durationMs - gettingResultTimeMs
+    }
+    info.markFinished(TaskState.FINISHED, launchTime + durationMs)
+    info
+  }
 
   /**
    * A real, empty TaskContext bound to the calling thread.


### PR DESCRIPTION
Closes #45

## Summary

Total stage duration says a stage was slow and nothing about why. Six attributes now say why, all on the existing `onStageCompleted` call site:

| Attribute | Source |
|---|---|
| `spark.stage.jvm.gc_time_ms` | `m.jvmGCTime` |
| `spark.stage.executor.deserialize_time_ms` | `m.executorDeserializeTime` |
| `spark.stage.executor.deserialize_cpu_time_ms` | `m.executorDeserializeCpuTime`, ns → ms like `executorCpuTime` |
| `spark.stage.result.serialization_time_ms` | `m.resultSerializationTime` |
| `spark.stage.disk.spilled_bytes` | `m.diskBytesSpilled` (we had only the memory half) |
| `spark.stage.scheduler.delay_ms` | derived — see below |

Each is Spark's own sum across the stage's tasks, so they are directly comparable with the existing `spark.stage.executor.run_time_ms`.

**Scheduler delay is the only one that needed new machinery.** It is not on `StageInfo.taskMetrics` — deriving it needs each task's wall clock, which only `SparkListenerTaskEnd` carries. So the listener gains an `onTaskEnd` that accumulates one `AtomicLong` per in-flight stage. Still no driver-side task spans; the class comment's rule is intact.

Three judgement calls worth reviewing:

- **Clamped per task, never on the sum.** The driver's clock and the executor's are different clocks, so a fast task can report a run time a few ms longer than its own duration. Summing first would let those negatives cancel real queueing measured elsewhere in the stage and quietly understate it. There is a test for exactly this.
- **Result fetch time is subtracted**, matching Spark's own `AppStatusUtils.schedulerDelay`. Note `TaskInfo.gettingResultTime` is the *instant* the fetch began, not an elapsed time, and is `0` when the result came back inline — using it directly as a duration would have made every delay clamp to zero.
- **Absent rather than `0` when no task ends were observed.** A zero reads as "no queueing"; the absence reads as "not measured", which is the truth.

Accumulator cleanup is unconditional at `onStageCompleted` (a stage whose span was never created still accumulated) plus `shutdown()`, so it cannot outlive the stage.

## Test plan
- [x] 9 new tests in `TracingSparkListenerTest`: breakdown attributes, ns→ms conversion, delay arithmetic, summing across tasks, result-fetch exclusion, per-task clamping, absent-when-unmeasured, per-stage attribution with two concurrent stages, and a null-`taskMetrics` task skipped without aborting the stage
- [x] Proven non-vacuous — with the implementation neutered, 7 of 9 fail. The two that do not are the negative assertions; the null-metrics one was strengthened with a healthy task in the same stage so it can no longer pass vacuously
- [x] `sbt -DsparkVersion=3.5.1 ++2.13.16 test` — 126 passed
- [x] `sbt -DsparkVersion=3.5.1 ++2.12.18 test` — 126 passed
- [x] `Test / compile` on 3.3.4, 3.4.3, 4.0.0 (2.13.16) — all `[success]`
- [x] `TaskInfo`, `SparkListenerTaskEnd`, the `TaskMetrics` setters and `markFinished` verified with `javap` to be signature-identical on 3.3.4/3.4.3/3.5.1/4.0.0, so the fixtures are real events on every matrix entry rather than loose-value stand-ins