### PR TITLE
Document the emitted telemetry and drop five dead attribute keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Telemetry reference in the README** — every span attribute Flare emits, grouped by span type,
+  and every metric instrument with its kind, unit and label set. None of this was documented
+  before: the only way to learn that `spark.sql.plan` or `spark.stage.scheduler.delay_ms` existed
+  was to read `SparkAttributes.scala`. Attributes that are conditional are marked as such, since a
+  missing attribute means "not measured" and is not the same as a measured zero ([#61])
 - **Stage timing breakdown** — `spark.stage.jvm.gc_time_ms`,
   `spark.stage.executor.deserialize_time_ms`, `spark.stage.executor.deserialize_cpu_time_ms`,
   `spark.stage.result.serialization_time_ms`, `spark.stage.disk.spilled_bytes` and
@@ -88,6 +93,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-initialization, and concurrent initialization race safety
 
 ### Changed
+- **Removed five never-emitted attribute keys** — `spark.version`, `spark.task.executor.id`,
+  `spark.task.host`, `spark.task.locality` and `spark.task.speculative` were declared in
+  `SparkAttributes` but never set on any span, so no consumer can have been reading them. The four
+  task keys are `TaskInfo` fields that only the driver sees, while `spark.task.executor` is built
+  from `TaskContext` on the executor, so they were never reachable from that call site. `error.type`
+  is also unset today but is retained, as [#46] will set it ([#61])
 - **OpenTelemetry baseline** — Java agent 2.30.0, API/SDK 1.64.0, and
   `byte-buddy-dep` 1.18.11
 - **Consumer dependency update** — `opentelemetry-api` and `opentelemetry-context` move from
@@ -244,9 +255,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#42]: https://github.com/Neutrinic/flare/issues/42
 [#44]: https://github.com/Neutrinic/flare/issues/44
 [#45]: https://github.com/Neutrinic/flare/issues/45
+[#46]: https://github.com/Neutrinic/flare/issues/46
 [#47]: https://github.com/Neutrinic/flare/issues/47
 [#52]: https://github.com/Neutrinic/flare/issues/52
 [#53]: https://github.com/Neutrinic/flare/issues/53
 [#54]: https://github.com/Neutrinic/flare/issues/54
 [#57]: https://github.com/Neutrinic/flare/issues/57
 [#58]: https://github.com/Neutrinic/flare/issues/58
+[#61]: https://github.com/Neutrinic/flare/issues/61

--- a/README.md
+++ b/README.md
@@ -209,6 +209,132 @@ if you run large elastic clusters.
 
 > **Note:** When a Spark job fails, exception messages are recorded as span attributes. Spark exceptions sometimes include snippets of the data being processed (e.g., parse errors, type mismatches). Ensure your telemetry backend is secured appropriately if your jobs handle sensitive data.
 
+## Telemetry Reference
+
+Everything below is what Flare actually emits. Attributes marked *conditional* are absent rather
+than zero when the underlying value was never observed — a missing attribute means "not measured",
+which is different from a measured zero.
+
+### `spark.application` — SpanKind SERVER, trace root
+
+Opened when `SparkContext` initialises, closed at `SparkContext.stop()`.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `spark.application.id` | string | `SparkContext.applicationId` |
+| `spark.application.name` | string | `SparkContext.appName` |
+| `spark.master.url` | string | `SparkContext.master` |
+| `flare.version` | string | Flare build version |
+| `flare.trace.granularity` | string | Effective `FLARE_TRACE_GRANULARITY` |
+
+### `spark.sql.N` — SpanKind INTERNAL, child of `spark.application`
+
+One per `SparkListenerSQLExecutionStart`. `N` is the execution id.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `spark.sql.execution.id` | long | Matches the `N` in the span name |
+| `spark.sql.description` | string | Conditional — omitted when Spark reports it empty. Capped by `FLARE_SQL_DESCRIPTION_MAX_CHARS` |
+| `spark.sql.details` | string | Conditional — the call-site stack. Capped by `FLARE_SQL_DETAILS_MAX_CHARS` |
+| `spark.sql.plan` | string | The physical plan **that ran**, post-AQE. Capped by `FLARE_SQL_PLAN_MAX_CHARS` |
+| `spark.sql.plan.truncated` | bool | Conditional — set only when the cap clipped the plan |
+| `spark.sql.plan.initial` | string | Conditional — the pre-AQE plan. Off unless `FLARE_SQL_PLAN_INITIAL_MAX_CHARS > 0` |
+| `spark.sql.plan.initial.truncated` | bool | Conditional — as above, for the initial plan |
+
+### `spark.job.N` — SpanKind INTERNAL, child of `spark.sql.N` or `spark.application`
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `spark.job.id` | long | |
+| `spark.job.stage.count` | long | Number of stages the job was planned with |
+| `spark.job.description` | string | Conditional — from `spark.job.description` local property |
+| `spark.job.result` | string | `SUCCESS` or `FAILED` |
+| `error.message` | string | Conditional — present only on `FAILED` |
+
+### `spark.stage.N` — SpanKind INTERNAL, child of `spark.job.N`
+
+Metrics below are Spark's own sums across every task in the stage, so they are directly comparable
+with each other. All are set at `onStageCompleted` from `StageInfo.taskMetrics`.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `spark.stage.id` | long | |
+| `spark.stage.attempt.id` | long | |
+| `spark.stage.name` | string | Spark's `RDD.creationSite` — the same string the Spark UI shows |
+| `spark.stage.task.count` | long | |
+| `spark.stage.executor.run_time_ms` | long | |
+| `spark.stage.executor.cpu_time_ms` | long | Converted from Spark's nanoseconds |
+| `spark.stage.jvm.gc_time_ms` | long | GC time rivalling run time is the answer to "why is this stage slow" |
+| `spark.stage.executor.deserialize_time_ms` | long | |
+| `spark.stage.executor.deserialize_cpu_time_ms` | long | Converted from nanoseconds |
+| `spark.stage.result.serialization_time_ms` | long | |
+| `spark.stage.scheduler.delay_ms` | long | Conditional — derived, see below |
+| `spark.stage.input.bytes` / `.records` | long | |
+| `spark.stage.output.bytes` / `.records` | long | |
+| `spark.stage.shuffle.read_bytes` | long | |
+| `spark.stage.shuffle.write_bytes` | long | |
+| `spark.stage.memory.spilled_bytes` | long | |
+| `spark.stage.disk.spilled_bytes` | long | |
+| `spark.stage.failure_reason` | string | Conditional — first 500 chars |
+
+`spark.stage.scheduler.delay_ms` is the only stage attribute Spark does not report. It is derived
+per task as `duration − executorRunTime − deserializeTime − resultSerializationTime −
+resultFetchTime` and summed over the stage, matching Spark's own `AppStatusUtils.schedulerDelay`.
+The clamp at zero is applied per task, never to the sum, because driver and executor clocks differ
+and a fast task can report more run time than its own wall clock. The attribute is **omitted** when
+no task ends were observed — a `0` there would read as "no queueing" rather than "not measured".
+
+### `spark.task.executor` — SpanKind INTERNAL, child of `spark.stage.N`, emitted on the executor JVM
+
+Subject to `FLARE_TRACE_GRANULARITY`, `FLARE_SLOW_TASK_MS`, `FLARE_RETRY_TASKS_ONLY` and
+`FLARE_MAX_SPANS_PER_TRACE`. This span is built from `TaskContext`, so driver-only `TaskInfo`
+fields (host, locality, speculative) are not available to it.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `spark.task.partition.id` | long | |
+| `spark.task.attempt.id` | long | `> 0` means a retry |
+| `spark.stage.id` | long | Conditional — only under `FLARE_TRACE_GRANULARITY=all`. The parent span already identifies the stage; this repeats it so you can filter without a join |
+| `spark.task.sql.execution_id` | long | Conditional — present when the task belongs to a SQL execution |
+| `spark.task.result` | string | `SUCCESS`, `FAILED`, or `SHUTDOWN` if the JVM went down mid-task |
+| `error.message` | string | Conditional — present only on `FAILED` |
+| `spark.task.duration_ms` | long | Wall clock on the executor thread |
+| `spark.task.input.bytes` / `output.bytes` | long | |
+| `spark.task.shuffle.read_bytes` / `write_bytes` | long | |
+| `spark.task.peak_memory_bytes` | long | |
+
+The four byte counts and peak memory come from `TaskContext.taskMetrics()`, which is
+`private[spark]` and can throw from outside `org.apache.spark` or in barrier mode. Flare logs at
+debug and emits the span without them rather than failing the task, so all five are absent together
+when that happens.
+
+### Metrics
+
+Nine instruments, all under the `io.flare.spark` meter, disabled wholesale by
+`FLARE_METRICS_ENABLED=false`.
+
+| Instrument | Kind | Unit | Labels |
+|------------|------|------|--------|
+| `flare.task.duration` | histogram | `ms` | `executor.id`, `stage.id`, `task.result` |
+| `flare.task.records_throughput` | histogram | `{records}/s` | `executor.id`, `stage.id`, `task.result` |
+| `flare.task.shuffle.read_bytes` | counter | `By` | `executor.id`, `stage.id`, `task.result` |
+| `flare.task.shuffle.write_bytes` | counter | `By` | `executor.id`, `stage.id`, `task.result` |
+| `flare.stage.executor.run_time` | histogram | `ms` | `stage.id`, `stage.name` |
+| `flare.stage.input.bytes` | counter | `By` | `stage.id`, `stage.name` |
+| `flare.stage.output.bytes` | counter | `By` | `stage.id`, `stage.name` |
+| `flare.stage.shuffle.read_bytes` | counter | `By` | `stage.id`, `stage.name` |
+| `flare.stage.shuffle.write_bytes` | counter | `By` | `stage.id`, `stage.name` |
+
+The counters are only incremented for non-zero values, so a stage that read nothing produces no
+`flare.stage.input.bytes` series rather than a flat zero one.
+
+`flare.task.*` are recorded on the executor while the task span's scope is still open, so the SDK's
+default `trace_based` exemplar filter attaches an exemplar linking each measurement back to its
+trace. Under `FLARE_SLOW_TASK_MS` the metric is recorded *after* the suppressed span's scope closes,
+so a fast task still contributes to the histogram but carries no exemplar pointing at a trace that
+was never exported. Note that some backends drop exemplars by default — Mimir's
+`max_global_exemplars_per_user` is `0` unless you set it.
+
 ## OTEL Agent Compatibility
 
 Flare is an OTEL Java agent **extension** — not a standalone library. It is loaded by the agent's `AgentClassLoader` and shares the agent's ByteBuddy and SDK classes at runtime. This means the agent version matters.

--- a/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
+++ b/src/main/scala/io/flare/spark/attributes/SparkAttributes.scala
@@ -5,10 +5,9 @@ import io.opentelemetry.api.common.AttributeKey
 object SparkAttributes {
 
   object Application {
-    val Id      = AttributeKey.stringKey("spark.application.id")
-    val Name    = AttributeKey.stringKey("spark.application.name")
-    val Master  = AttributeKey.stringKey("spark.master.url")
-    val Version = AttributeKey.stringKey("spark.version")
+    val Id     = AttributeKey.stringKey("spark.application.id")
+    val Name   = AttributeKey.stringKey("spark.application.name")
+    val Master = AttributeKey.stringKey("spark.master.url")
   }
 
   object Job {
@@ -73,14 +72,16 @@ object SparkAttributes {
     val PlanInitialTruncated = AttributeKey.booleanKey("spark.sql.plan.initial.truncated")
   }
 
+  /**
+   * Attributes on the `spark.task.executor` span, which is created on the EXECUTOR JVM from
+   * `TaskContext`. That is the constraint on what can live here: host, locality and speculative
+   * are `TaskInfo` fields that only the driver ever sees, so they are not available at this
+   * span's call site.
+   */
   object Task {
-    val ExecutorId  = AttributeKey.stringKey("spark.task.executor.id")
-    val Host        = AttributeKey.stringKey("spark.task.host")
     val PartitionId = AttributeKey.longKey("spark.task.partition.id")
     val AttemptId   = AttributeKey.longKey("spark.task.attempt.id")
-    val Speculative = AttributeKey.booleanKey("spark.task.speculative")
     val Result      = AttributeKey.stringKey("spark.task.result")
-    val Locality    = AttributeKey.stringKey("spark.task.locality")
     // v0.2 — task-level metrics (recorded at task end from TaskMetrics)
     val ShuffleReadBytes  = AttributeKey.longKey("spark.task.shuffle.read_bytes")
     val ShuffleWriteBytes = AttributeKey.longKey("spark.task.shuffle.write_bytes")
@@ -93,6 +94,7 @@ object SparkAttributes {
 
   // OTEL semantic conventions
   object Error {
+    // Not yet set anywhere — see #46, which pairs it with Span.recordException.
     val Type    = AttributeKey.stringKey("error.type")
     val Message = AttributeKey.stringKey("error.message")
   }


### PR DESCRIPTION
Closes #61

## Summary

Flare emits 45 span attributes and 9 metric instruments and documented none of them. The README named exactly two (`spark.sql.plan`, `spark.sql.plan.truncated`) and only in passing, while explaining a config cap. Discovering that `spark.stage.scheduler.delay_ms` exists required reading `SparkAttributes.scala`.

Adds a **Telemetry Reference** section covering each span type in the hierarchy — `spark.application`, `spark.sql.N`, `spark.job.N`, `spark.stage.N`, `spark.task.executor` — with every attribute set on it, plus the nine metric instruments with kind, unit and label set. Attributes are marked *conditional* where they can be absent, because a missing attribute means "not measured" and is not the same as a measured zero; `spark.stage.scheduler.delay_ms` is exactly this case.

Two things the reference makes visible that were not obvious from the source:
- `spark.stage.id` on the task span is only set under `FLARE_TRACE_GRANULARITY=all` (`FlareExecutorPlugin.scala:148`)
- the five `TaskMetrics`-derived task attributes are absent *together* when `TaskContext.taskMetrics()` throws, which it can do from outside `org.apache.spark` or in barrier mode

## Dead keys

Auditing every declared key against its call sites found six that are never set anywhere in `src/main`. Documenting them as emitted would repeat the problem #54 fixed: an attribute that states something untrue.

| Key | Why it was unreachable |
|---|---|
| `spark.version` | `FlareDriverPlugin.scala:67-71` sets Name/Id/Master only |
| `spark.task.executor.id` | executor id only ever reaches the metric label `executor.id` |
| `spark.task.host` | `TaskInfo` field, driver-only |
| `spark.task.locality` | `TaskInfo` field, driver-only |
| `spark.task.speculative` | `TaskInfo` field, driver-only |

Those five are removed. The task ones share a root cause worth recording in the code: `spark.task.executor` is built on the executor from `TaskContext`, which does not carry `TaskInfo`, so they were never obtainable at that call site — a comment on `object Task` now says so.

`error.type` is also unset today but is **retained**, since #46 will set it alongside `Span.recordException`. It carries a comment pointing there.

No emitted attribute changed name, type or presence, so the trace shape is untouched.

## Test plan
- [x] `sbt -DsparkVersion=3.5.1 ++2.13.16 test` — 137 passed
- [x] `sbt -DsparkVersion=3.5.1 ++2.12.18 test` — 137 passed
- [x] `Test / compile` on 3.3.4, 3.4.3, 4.0.0 — all green (removing the keys could only break a reference, and none exist)
- [x] Every attribute and instrument in the reference traced back to the line that sets it; the six with no such line are handled above rather than documented