### PR TITLE
Backfill the 1.0.0 changelog and cut 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-01
+
 ### Added
 - **Telemetry reference in the README** — every span attribute Flare emits, grouped by span type,
   and every metric instrument with its kind, unit and label set. None of this was documented
@@ -51,46 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Real-agent extension test** — a forked JVM runs the supported OpenTelemetry Java agent with
   Flare's assembled JAR, then verifies the packaged SPI descriptor, generated version metadata,
   and exported `flare.role` / `flare.version` resource attributes
-- **OTEL metrics instruments** — task-level `DoubleHistogram` for duration and throughput,
-  `LongCounter` for shuffle bytes, recorded in `FlareExecutorPlugin.endTask()` with automatic
-  exemplar linking (metrics recorded while span scope is active). Stage-level counters and
-  histograms recorded in `TracingSparkListener.onStageCompleted()` for executor run time,
-  input/output bytes, and shuffle bytes ([#10], [#11])
-- **`FLARE_METRICS_ENABLED`** — kill switch for OTEL metrics emission (default `true`).
-  When disabled, all instruments use a no-op meter with zero overhead
-- **`FlareMetrics`** — centralized holder for all OTEL metric instruments, constructed from
-  a `Meter` instance for testability. Factory method `FlareMetrics.create(enabled)` selects
-  real vs no-op meter
-- **`MetricAttributes`** — helper for building `Attributes` with correct Scala→Java Long
-  boxing for metric dimensional tags (`executor.id`, `stage.id`, `task.result`, `stage.name`)
-- **Per-stage traceparent injection** — `SubmitMissingTasksInstrumentation` hooks
-  `DAGScheduler.submitMissingTasks(stage, jobId)` via ByteBuddy to inject a per-stage
-  traceparent into `ActiveJob.properties` before tasks are created. Executor task spans now
-  nest under their specific stage span (`app → job → stage → task`). Captures ALL stages
-  including AQE (Adaptive Query Execution) sub-jobs that bypass `SparkContext.runJob`.
-  Job and stage spans are pre-created via reflection on DAGScheduler internals, then adopted
-  by `TracingSparkListener` when `onJobStart`/`onStageSubmitted` fire. Backward compatible
-  with SparkPlugin-only mode ([#26])
-- **ByteBuddy TaskRunner context restoration** — `TaskRunnerInstrumentationModule` hooks
-  `Executor$TaskRunner.run()` to extract `traceparent` from `TaskDescription.properties`
-  and make the parent OTEL context current for the entire task execution. Downstream
-  OTEL-instrumented libraries (JDBC, HTTP, gRPC) inside tasks now inherit the correct
-  parent context. Context-only — no span creation, `FlareExecutorPlugin` manages span
-  lifecycle as before ([#15])
-- **`LocalPropertyPropagator.extractFromProperties`** — overloaded extraction method taking
-  `java.util.Properties` directly for use in TaskRunner advice where `TaskContext` is null
-- **ByteBuddy SparkContext auto-registration** — `SparkContextInstrumentationModule` hooks
-  `SparkContext.<init>` constructor exit via ByteBuddy advice to auto-register
-  `TracingSparkListener` and create the application span without `spark.plugins` config.
-  True zero-config when using the OTEL agent extension ([#14])
-- **FlareDriverState** — shared state holder with `@volatile` + `synchronized` guard for
-  dedup between SparkPlugin (Phase 1) and ByteBuddy (Phase 2) paths. First path to
-  initialize wins; the other is a no-op
-- **InstrumentationModule SPI** — `META-INF/services/` registration for auto-discovery by
-  the OTEL Java agent. Module, TypeInstrumentation, and Advice written in Java for agent
-  classloader compatibility (Scala runtime not available in extension classloader)
-- **FlareDriverState tests** — 8 tests covering initialization, dedup, shutdown idempotency,
-  re-initialization, and concurrent initialization race safety
 
 ### Changed
 - **Removed five never-emitted attribute keys** — `spark.version`, `spark.task.executor.id`,
@@ -107,8 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preserve consumers, but applications should validate dependency convergence when upgrading
 - **Startup diagnostics** — all live Scala initialization paths log the active trace granularity,
   sampling ratio, and maximum spans per trace after configuration validation
-- **Dockerfile stable JAR names** — `COPY flare-spark.jar` and `COPY flare-examples.jar`
-  instead of `flare-spark-assembly-${FLARE_VERSION}.jar`; removed `FLARE_VERSION` build arg
 
 ### Fixed
 - **`spark.sql.plan` is the plan that ran, not the pre-AQE tree** — `SparkListenerSQLExecutionStart`
@@ -179,6 +139,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   injection and `spark.task → spark.stage` parenting. Executors recover the correct parent from
   task properties through the plugin without needing the extension. Useful where a stable JAR
   path exists on the driver but not cluster-wide ([#42])
+
+## [1.0.0] - 2026-02-28
+
+### Added
+- **OTEL metrics instruments** — task-level `DoubleHistogram` for duration and throughput,
+  `LongCounter` for shuffle bytes, recorded in `FlareExecutorPlugin.endTask()` with automatic
+  exemplar linking (metrics recorded while span scope is active). Stage-level counters and
+  histograms recorded in `TracingSparkListener.onStageCompleted()` for executor run time,
+  input/output bytes, and shuffle bytes ([#10], [#11])
+- **`FLARE_METRICS_ENABLED`** — kill switch for OTEL metrics emission (default `true`).
+  When disabled, all instruments use a no-op meter with zero overhead
+- **`FlareMetrics`** — centralized holder for all OTEL metric instruments, constructed from
+  a `Meter` instance for testability. Factory method `FlareMetrics.create(enabled)` selects
+  real vs no-op meter
+- **`MetricAttributes`** — helper for building `Attributes` with correct Scala→Java Long
+  boxing for metric dimensional tags (`executor.id`, `stage.id`, `task.result`, `stage.name`)
+- **Per-stage traceparent injection** — `SubmitMissingTasksInstrumentation` hooks
+  `DAGScheduler.submitMissingTasks(stage, jobId)` via ByteBuddy to inject a per-stage
+  traceparent into `ActiveJob.properties` before tasks are created. Executor task spans now
+  nest under their specific stage span (`app → job → stage → task`). Captures ALL stages
+  including AQE (Adaptive Query Execution) sub-jobs that bypass `SparkContext.runJob`.
+  Job and stage spans are pre-created via reflection on DAGScheduler internals, then adopted
+  by `TracingSparkListener` when `onJobStart`/`onStageSubmitted` fire. Backward compatible
+  with SparkPlugin-only mode ([#26])
+- **ByteBuddy TaskRunner context restoration** — `TaskRunnerInstrumentationModule` hooks
+  `Executor$TaskRunner.run()` to extract `traceparent` from `TaskDescription.properties`
+  and make the parent OTEL context current for the entire task execution. Downstream
+  OTEL-instrumented libraries (JDBC, HTTP, gRPC) inside tasks now inherit the correct
+  parent context. Context-only — no span creation, `FlareExecutorPlugin` manages span
+  lifecycle as before ([#15])
+- **`LocalPropertyPropagator.extractFromProperties`** — overloaded extraction method taking
+  `java.util.Properties` directly for use in TaskRunner advice where `TaskContext` is null
+- **ByteBuddy SparkContext auto-registration** — `SparkContextInstrumentationModule` hooks
+  `SparkContext.<init>` constructor exit via ByteBuddy advice to auto-register
+  `TracingSparkListener` and create the application span without `spark.plugins` config.
+  True zero-config when using the OTEL agent extension ([#14])
+- **FlareDriverState** — shared state holder with `@volatile` + `synchronized` guard for
+  dedup between SparkPlugin (Phase 1) and ByteBuddy (Phase 2) paths. First path to
+  initialize wins; the other is a no-op
+- **InstrumentationModule SPI** — `META-INF/services/` registration for auto-discovery by
+  the OTEL Java agent. Module, TypeInstrumentation, and Advice written in Java for agent
+  classloader compatibility (Scala runtime not available in extension classloader)
+- **FlareDriverState tests** — 8 tests covering initialization, dedup, shutdown idempotency,
+  re-initialization, and concurrent initialization race safety
+
+### Changed
+- **Dockerfile stable JAR names** — `COPY flare-spark.jar` and `COPY flare-examples.jar`
+  instead of `flare-spark-assembly-${FLARE_VERSION}.jar`; removed `FLARE_VERSION` build arg
 
 ## [0.2.0] - 2026-02-27
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Download the JAR matching your Spark version from
 
 ```bash
 spark-submit \
-  --packages io.github.neutrinic:flare-spark-3-5_2.13:1.0.0 \
+  --packages io.github.neutrinic:flare-spark-3-5_2.13:1.1.0 \
   --conf "spark.plugins=io.flare.spark.plugin.FlareSparkPlugin" \
   --conf "spark.driver.extraJavaOptions=\
     -javaagent:/opt/flare/opentelemetry-javaagent.jar \
@@ -114,13 +114,13 @@ spark-submit \
 Pick the artifact matching your Spark version:
 
 ```
-io.github.neutrinic:flare-spark-3-3_2.12:1.0.0   # Spark 3.3, Scala 2.12
-io.github.neutrinic:flare-spark-3-3_2.13:1.0.0   # Spark 3.3, Scala 2.13
-io.github.neutrinic:flare-spark-3-4_2.12:1.0.0   # Spark 3.4, Scala 2.12
-io.github.neutrinic:flare-spark-3-4_2.13:1.0.0   # Spark 3.4, Scala 2.13
-io.github.neutrinic:flare-spark-3-5_2.12:1.0.0   # Spark 3.5, Scala 2.12
-io.github.neutrinic:flare-spark-3-5_2.13:1.0.0   # Spark 3.5, Scala 2.13
-io.github.neutrinic:flare-spark-4-0_2.13:1.0.0   # Spark 4.0, Scala 2.13
+io.github.neutrinic:flare-spark-3-3_2.12:1.1.0   # Spark 3.3, Scala 2.12
+io.github.neutrinic:flare-spark-3-3_2.13:1.1.0   # Spark 3.3, Scala 2.13
+io.github.neutrinic:flare-spark-3-4_2.12:1.1.0   # Spark 3.4, Scala 2.12
+io.github.neutrinic:flare-spark-3-4_2.13:1.1.0   # Spark 3.4, Scala 2.13
+io.github.neutrinic:flare-spark-3-5_2.12:1.1.0   # Spark 3.5, Scala 2.12
+io.github.neutrinic:flare-spark-3-5_2.13:1.1.0   # Spark 3.5, Scala 2.13
+io.github.neutrinic:flare-spark-4-0_2.13:1.1.0   # Spark 4.0, Scala 2.13
 ```
 
 The OTEL Java agent JAR (`opentelemetry-javaagent.jar`) must still be placed on every node — `--packages` handles only Flare and its dependencies.


### PR DESCRIPTION
Closes #63

## Summary

Release prep for 1.1.0, which turned up a real defect first.

`CHANGELOG.md` had **no `## [1.0.0]` section**. It went `[Unreleased]` → `[0.2.0]`, because the Unreleased block was never promoted when `v1.0.0` was tagged. Everything that shipped in 1.0.0 was still sitting under Unreleased, interleaved with the 1.1.0 work — so promoting it wholesale would have credited 1.1.0 with per-stage traceparent injection (#26), both ByteBuddy instrumentation modules (#14, #15), the OTEL metrics instruments (#10, #11) and `FlareDriverState`.

This backfills `## [1.0.0] - 2026-02-28` and promotes the remainder to `## [1.1.0] - 2026-08-01`.

The split is not a judgement call: `git show v1.0.0:CHANGELOG.md` **is** the 1.0.0 content. The backfilled section is byte-identical to it, asserted programmatically rather than eyeballed. The two entries whose side of the boundary was not obvious were resolved with `git log -S` against `CHANGELOG.md`:

| Entry | Introduced by | Side |
|---|---|---|
| Real-agent extension test | `394d7c7` (#41) | 1.1.0 |
| Startup diagnostics | `394d7c7` (#41) | 1.1.0 |
| Dockerfile stable JAR names | `125cc24` (#24) | 1.0.0 |

Also moves the seven `--packages` coordinates in the README from `1.0.0` to `1.1.0`.

## Why 1.1.0 and not 2.0

The emitted trace shape — span names, hierarchy, and every attribute a dashboard or alert could be reading — is unchanged. The five attribute keys removed in #61 were never set on any span, so nothing could have consumed them.

The one consumer-visible change is the OpenTelemetry API/context bump, 1.50.0 → 1.64.0. Both are compile-scoped and bundled in the assembly, so it moves the published POM dependency graph *and* the shipped bytecode. It stays a minor under OpenTelemetry's 1.x compatibility guarantee, but it is the item to lead the release notes with.

## Test plan
- [x] Backfilled `[1.0.0]` section asserted byte-identical to `git show v1.0.0:CHANGELOG.md`
- [x] Boundary entries traced to their introducing commit with `git log -S`
- [x] No remaining `1.0.0` coordinate references outside the changelog history
- [ ] CI green — docs-only change, but the matrix confirms nothing else moved

After merge: tag `v1.1.0`, which triggers `release.yml` → `ci-release` across the 7-entry Spark x Scala matrix.