### PR TITLE
Publish each coordinate once by dropping the Scala matrix axis

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,25 +10,20 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      # Coordinates are disjoint across jobs (see below), so a failure in one says
+      # nothing about the others. Cancelling a sibling mid-upload would leave a
+      # partial deployment on the Central Portal, which cannot be re-cut.
+      fail-fast: false
       matrix:
-        include:
-          - spark: "3.3.4"
-            scala: "2.12.18"
-          - spark: "3.3.4"
-            scala: "2.13.16"
-          - spark: "3.4.3"
-            scala: "2.12.18"
-          - spark: "3.4.3"
-            scala: "2.13.16"
-          - spark: "3.5.1"
-            scala: "2.12.18"
-          - spark: "3.5.1"
-            scala: "2.13.16"
-          - spark: "4.0.0"
-            scala: "2.13.16"
+        # Spark axis ONLY. `ci-release` runs `+publishSigned`, and the `+` cross-builds
+        # every entry in `crossScalaVersions` regardless of any preceding `++`. Adding a
+        # Scala axis therefore does not split the work — it makes each job publish the
+        # SAME coordinates, and concurrent jobs collide on the Central Portal with
+        # "currently being published in another deployment". Scala comes from
+        # `crossScalaVersions` in build.sbt, which already scopes Spark 4.0 to 2.13.
+        spark: ["3.3.4", "3.4.3", "3.5.1", "4.0.0"]
 
-    name: Publish Spark ${{ matrix.spark }} / Scala ${{ matrix.scala }}
+    name: Publish Spark ${{ matrix.spark }}
 
     steps:
       - uses: actions/checkout@v6
@@ -43,7 +38,7 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - name: Publish to Maven Central
-        run: sbt -DsparkVersion=${{ matrix.spark }} ++${{ matrix.scala }} ci-release
+        run: sbt -DsparkVersion=${{ matrix.spark }} ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Release workflow published every coordinate twice** — the matrix had a Scala axis, but
+  `ci-release` runs `+publishSigned` and the `+` cross-builds all of `crossScalaVersions`
+  regardless of any preceding `++`. Each of the 7 jobs therefore published the full Scala set for
+  its Spark version, so 13 uploads raced for 7 coordinates and the Central Portal rejected the
+  duplicates. Combined with `fail-fast: true` this cancelled healthy sibling jobs mid-upload. The
+  matrix is now the Spark axis alone — 4 jobs, disjoint coordinates — with `fail-fast: false`.
+  The set of published artifacts is unchanged ([#65])
+
 ## [1.1.0] - 2026-08-01
 
 ### Added
@@ -271,3 +280,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#57]: https://github.com/Neutrinic/flare/issues/57
 [#58]: https://github.com/Neutrinic/flare/issues/58
 [#61]: https://github.com/Neutrinic/flare/issues/61
+[#65]: https://github.com/Neutrinic/flare/issues/65


### PR DESCRIPTION
Closes #65

## Summary

`ci-release` runs `+publishSigned`. The `+` cross-builds every entry in `crossScalaVersions` and **ignores any preceding `++`** — verified by disassembling `CiReleasePlugin$.backPubVersionToCommand`, which returns the literal `+publishSigned` for any version without an `@`.

The Scala matrix axis therefore split nothing. Each of the 7 jobs published the *full* Scala set for its Spark version:

| job | coordinates published |
|---|---|
| 3.3.4 / 2.12 | `flare-spark-3-3_2.12`, `flare-spark-3-3_2.13` |
| 3.3.4 / 2.13 | `flare-spark-3-3_2.12`, `flare-spark-3-3_2.13` ← identical |
| 3.4.3 / 2.12 | `flare-spark-3-4_2.12`, `flare-spark-3-4_2.13` |
| 3.4.3 / 2.13 | `flare-spark-3-4_2.12`, `flare-spark-3-4_2.13` ← identical |
| 3.5.1 / 2.12 | `flare-spark-3-5_2.12`, `flare-spark-3-5_2.13` |
| 3.5.1 / 2.13 | `flare-spark-3-5_2.12`, `flare-spark-3-5_2.13` ← identical |
| 4.0.0 / 2.13 | `flare-spark-4-0_2.13` |

13 uploads for 7 coordinates, 6 of them exact duplicates racing concurrently. This is why the v1.1.0 run failed with `Component with coordinate '...' is currently being published in another deployment` — and why the failing job was `Spark 3.4.3 / Scala 2.12.18` yet collided on a `_2.13` coordinate.

The changes:

- **Matrix is the Spark axis alone** — 4 jobs, disjoint coordinates. Scala comes from `crossScalaVersions`, which already scopes Spark 4.0 to 2.13 only (`build.sbt:71`), so 4.0 needs no special case.
- **`fail-fast: false`** — coordinates are disjoint, so one job failing says nothing about the others. Cancelling a sibling mid-upload can strand a partial deployment on the Central Portal, and published coordinates cannot be deleted, overwritten or re-cut.
- **A comment explaining why there is no Scala axis**, so it does not get re-added.

v1.1.0 survived this by luck: the collision landed on a coordinate a sibling job had already finished publishing. Nothing about the release itself needs redoing — all 7 coordinates are live and verified.

## Test plan

- [x] Disassembled `sbt-ci-release` 1.11.1 to confirm `ci-release` → `+publishSigned` unconditionally
- [x] `sbt -DsparkVersion=3.3.4 ++2.12.18 +publishM2` published **both** `_2.12` and `_2.13`, proving the `++` prefix is ignored and the duplication is real
- [x] Ran `+publishM2` for each of the 4 matrix entries into a scratch repo; the union is exactly 7 coordinates with **no overlap between jobs**
- [x] Those 7 are byte-for-byte the same coordinate set that is live on Maven Central for v1.1.0 (all `200`), so this is not a coverage regression
- [x] `publish / skip := true` on `examples` is honoured — `flare-examples` never appears
- [ ] Final confirmation only comes at the next tag push, since a real publish cannot be dry-run against Central